### PR TITLE
diagnose #12: confirm wnat_test.14 lacks Bermuda + slim-fixture extractor

### DIFF
--- a/scripts/diagnose_wnat_bermuda.py
+++ b/scripts/diagnose_wnat_bermuda.py
@@ -1,0 +1,129 @@
+"""Diagnose whether the WNAT fixture contains Bermuda as a topological feature.
+
+Issue #12 ("WNAT fresh mesh missing Bermuda boundary feature") asks whether
+``tests/fixtures/fort14/adcirc_examples/wnat_test.14`` actually carries
+Bermuda as a hole/island, or whether the fixture is a coarse pedagogical
+mesh that omits small islands. This script answers that question against
+the committed fixture (or any fort.14 you point it at) by checking three
+independent signals near (-64.78, 32.30):
+
+    1. Declared boundary segments in the fort.14 header.
+    2. Topological boundary edges (edges shared by exactly one triangle).
+    3. Bathymetry near the target — shallow/positive elevation would
+       indicate a sub-aerial feature; deep open-ocean values rule it out.
+
+Run::
+
+    python scripts/diagnose_wnat_bermuda.py
+    python scripts/diagnose_wnat_bermuda.py path/to/other.14
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import numpy as np
+
+import admesh
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURE = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "fort14"
+    / "adcirc_examples"
+    / "wnat_test.14"
+)
+BERMUDA = np.array([-64.78, 32.30])
+RADIUS_DEG = 1.5
+
+
+def _topological_boundary_nodes(elements: np.ndarray) -> set[int]:
+    edge_count: dict[tuple[int, int], int] = {}
+    for tri in elements:
+        a, b, c = int(tri[0]), int(tri[1]), int(tri[2])
+        for u, v in ((a, b), (b, c), (c, a)):
+            key = (u, v) if u < v else (v, u)
+            edge_count[key] = edge_count.get(key, 0) + 1
+    nodes: set[int] = set()
+    for (u, v), count in edge_count.items():
+        if count == 1:
+            nodes.add(u)
+            nodes.add(v)
+    return nodes
+
+
+def diagnose(path: pathlib.Path) -> int:
+    print(f"Fixture: {path}")
+    mesh = admesh.read_fort14(path)
+    print(
+        f"  n_nodes={mesh.n_nodes}, n_elements={mesh.n_elements}, "
+        f"declared boundaries in header={mesh.n_boundaries}"
+    )
+    print(
+        f"  bbox: x [{mesh.nodes[:, 0].min():.3f}, {mesh.nodes[:, 0].max():.3f}], "
+        f"y [{mesh.nodes[:, 1].min():.3f}, {mesh.nodes[:, 1].max():.3f}]"
+    )
+
+    d = np.linalg.norm(mesh.nodes - BERMUDA, axis=1)
+    near_idx = np.where(d < RADIUS_DEG)[0]
+    print(
+        f"\n[1] Nodes within {RADIUS_DEG}° of Bermuda {tuple(BERMUDA)}: "
+        f"{len(near_idx)}"
+    )
+
+    boundary_nodes = _topological_boundary_nodes(mesh.elements)
+    on_boundary = boundary_nodes.intersection(near_idx.tolist())
+    print(
+        f"[2] Of those, on a topological boundary edge "
+        f"(edge in exactly 1 triangle): {len(on_boundary)}"
+    )
+
+    if mesh.bathymetry is not None and len(near_idx) > 0:
+        z = mesh.bathymetry[near_idx]
+        print(
+            f"[3] Mesh-elevation samples near Bermuda "
+            f"(positive-up per Mesh contract): "
+            f"min={z.min():.1f}, mean={z.mean():.1f}, max={z.max():.1f}"
+        )
+    else:
+        print("[3] No bathymetry available.")
+
+    if not on_boundary:
+        b_nodes_arr = np.array(sorted(boundary_nodes), dtype=int)
+        if b_nodes_arr.size:
+            b_d = np.linalg.norm(mesh.nodes[b_nodes_arr] - BERMUDA, axis=1)
+            nearest = int(b_nodes_arr[int(b_d.argmin())])
+            print(
+                f"\nNearest topological-boundary node to Bermuda: "
+                f"{nearest} at ({mesh.nodes[nearest, 0]:.3f}, "
+                f"{mesh.nodes[nearest, 1]:.3f}), "
+                f"distance {b_d.min():.3f}°"
+            )
+
+    print()
+    if on_boundary:
+        print("VERDICT: Bermuda IS topologically present in this fixture.")
+        return 0
+    else:
+        print("VERDICT: Bermuda is NOT topologically present.")
+        print(
+            "  The mesh is fully connected through the Bermuda region; "
+            "the round-trip cannot recover what the source does not carry."
+        )
+        return 1
+
+
+def main(argv: list[str]) -> int:
+    path = pathlib.Path(argv[1]) if len(argv) > 1 else DEFAULT_FIXTURE
+    if not path.exists():
+        print(f"error: {path} does not exist", file=sys.stderr)
+        return 2
+    return diagnose(path)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/extract_boundary_only_fort14.py
+++ b/scripts/extract_boundary_only_fort14.py
@@ -1,0 +1,156 @@
+"""Extract boundary rings from a fort.14 mesh and write a slim fort.14.
+
+Brute-force size reduction for committed test fixtures: take a real
+upstream ADCIRC mesh (which may be tens of MB and well outside our
+``tests/fixtures/fort14/`` 500 KB budget), keep only the topological
+boundary, and re-triangulate the resulting polygon at coarse resolution
+so the round-trip ``Domain.from_mesh`` test has data with islands /
+holes (e.g. Bermuda) without checking in the full upstream mesh.
+
+Pipeline
+--------
+    upstream fort.14
+        │
+        ├── read_fort14
+        ├── walk topological boundary edges (edges in exactly 1 triangle)
+        ├── chain into rings, sort by signed area (outer first)
+        │
+        ├── domain_from_polygon([outer, *holes])    ← Shapely SDF
+        ├── triangulate(...)                        ← coarse h_max
+        │
+        └── write_fort14(slim)
+
+Run::
+
+    python scripts/extract_boundary_only_fort14.py \\
+        path/to/upstream.14 \\
+        tests/fixtures/fort14/community/wnat_islands.14 \\
+        --h-max 0.5
+
+Defaults emit a coarse h_max ≈ bbox_diag / 30 mesh, which for a typical
+WNAT-extent input lands well under 200 KB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import numpy as np
+
+import admesh
+from admesh.api import _derive_boundary_segments
+
+
+def _ring_area(ring_xy: np.ndarray) -> float:
+    x = ring_xy[:, 0]
+    y = ring_xy[:, 1]
+    return 0.5 * abs(
+        np.sum(x[:-1] * y[1:] - x[1:] * y[:-1])
+        + x[-1] * y[0]
+        - x[0] * y[-1]
+    )
+
+
+def _ensure_ccw(ring_xy: np.ndarray) -> np.ndarray:
+    x = ring_xy[:, 0]
+    y = ring_xy[:, 1]
+    signed = 0.5 * (
+        np.sum(x[:-1] * y[1:] - x[1:] * y[:-1])
+        + x[-1] * y[0]
+        - x[0] * y[-1]
+    )
+    return ring_xy if signed >= 0 else ring_xy[::-1]
+
+
+def extract(
+    src_path: pathlib.Path,
+    dst_path: pathlib.Path,
+    h_max: float | None,
+    quality_floor: float,
+) -> None:
+    print(f"reading {src_path} ...")
+    src = admesh.read_fort14(src_path)
+    print(
+        f"  source: {src.n_nodes} nodes, {src.n_elements} elements, "
+        f"declared boundaries={src.n_boundaries}"
+    )
+
+    segs = _derive_boundary_segments(src.elements, src.nodes)
+    if not segs:
+        sys.exit("error: source mesh has no topological boundary edges")
+
+    rings_xy = [src.nodes[s.node_ids] for s in segs]
+    ranked = sorted(
+        rings_xy, key=_ring_area, reverse=True
+    )  # outer = largest area
+    outer = _ensure_ccw(ranked[0])
+    holes = [_ensure_ccw(r)[::-1] for r in ranked[1:]]  # holes opposite
+    print(
+        f"  derived {len(rings_xy)} ring(s); outer area={_ring_area(outer):.4f}, "
+        f"holes={len(holes)} (areas: "
+        + ", ".join(f"{_ring_area(h):.4f}" for h in holes[:5])
+        + (", ...)" if len(holes) > 5 else ")")
+    )
+
+    bbox_diag = float(
+        np.hypot(
+            outer[:, 0].max() - outer[:, 0].min(),
+            outer[:, 1].max() - outer[:, 1].min(),
+        )
+    )
+    if h_max is None:
+        h_max = bbox_diag / 30.0
+    print(f"  triangulating at h_max={h_max:.4f}  (bbox diag={bbox_diag:.2f})")
+
+    domain = admesh.domain_from_polygon([outer, *holes])
+    new = admesh.triangulate(
+        domain,
+        h_max=h_max,
+        seed=0,
+        max_iter=80,
+        quality_gate=(quality_floor, 0.0),
+    )
+    print(f"  slim mesh: {new.n_nodes} nodes, {new.n_elements} elements")
+
+    new = admesh.Mesh(
+        nodes=new.nodes,
+        elements=new.elements,
+        boundaries=new.boundaries,
+        quality=new.quality,
+        title=f"slim re-mesh from {src_path.name} (boundary-only)",
+    )
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    new.to_fort14(dst_path)
+    size_kb = dst_path.stat().st_size / 1024.0
+    print(f"  wrote {dst_path} ({size_kb:.1f} KB)")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("src", type=pathlib.Path, help="upstream fort.14 to read")
+    p.add_argument("dst", type=pathlib.Path, help="slim fort.14 to write")
+    p.add_argument(
+        "--h-max",
+        type=float,
+        default=None,
+        help="target edge length in source coordinates "
+        "(default: bbox_diag / 30)",
+    )
+    p.add_argument(
+        "--quality-floor",
+        type=float,
+        default=0.10,
+        help="minimum acceptable per-element quality (default 0.10)",
+    )
+    args = p.parse_args(argv)
+    if not args.src.exists():
+        print(f"error: {args.src} does not exist", file=sys.stderr)
+        return 2
+    extract(args.src, args.dst, args.h_max, args.quality_floor)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/fixtures/fort14/README.md
+++ b/tests/fixtures/fort14/README.md
@@ -46,6 +46,23 @@ fixture.
   `tests/test_fort14_reference_corpus.py` and the
   `scripts/wnat_demo.py` end-to-end demo.
 
+  **Known data limitation — Bermuda is absent.** Despite the bbox
+  covering Bermuda's location (-64.78°W, 32.30°N), this small
+  variant carries no topological boundary in that region: 134 nodes
+  lie within 1.5° of Bermuda but none participate in a one-triangle
+  edge, and bathymetry there is uniformly 488–4811 m deep. The mesh
+  smooths over the Bermuda platform entirely. Verify with::
+
+      python scripts/diagnose_wnat_bermuda.py
+
+  See issue #12 for the investigation. A higher-resolution upstream
+  WNAT (HSOFS, EC2015, or the QuADMesh-MATLAB reference fixture)
+  is required to round-trip Bermuda as a hole. To produce a slim
+  budget-friendly fixture from any such upstream::
+
+      python scripts/extract_boundary_only_fort14.py upstream.14 \
+          tests/fixtures/fort14/community/wnat_islands.14
+
 ### `community/`
 
 _(none yet — populated by T027)_


### PR DESCRIPTION
Investigation + tooling for issue #12 ("WNAT fresh mesh missing Bermuda boundary feature"). **No code changes to `admesh/fort14.py` or `admesh/api.py` — neither is at fault.**

## Verdict

The `tests/fixtures/fort14/adcirc_examples/wnat_test.14` fixture genuinely does **not** carry Bermuda topologically. Three independent signals confirm it:

| Signal | Value | Meaning |
|---|---|---|
| Declared boundaries in fort.14 header | 0 open + 0 land | Header doesn't claim any |
| Topological boundary edges within 1.5° of Bermuda | 0 of 134 nearby nodes | Mesh is fully connected through the region |
| Bathymetry within 2° of Bermuda | min/max/mean = 488 / 4811 / 3920 m deep | No shelf, no sub-aerial feature |

The mesh smooths over the Bermuda platform entirely. The round-trip cannot recover what the source does not carry.

## Survey of public open-source ADCIRC fort.14 candidates

Checked everything I could reach (sandbox firewalled to GitHub-hosted content; `adcirc.org`, `dropbox.com`, `noaa.gov`, `ccht.ccee.ncsu.edu`, `nd.edu` all 403). None carry Bermuda as a hole:

| Source | NN / NE | Bermuda? |
|---|---|---|
| `adcirc/adcirc-testsuite` katrina-2d | 8 303 / 14 761 | bbox covers WNAT, but closest near-Bermuda node at -4085 m (deep ocean) |
| `adcirc/adcirc-testsuite` irene_*, apes | 1 069 / 1 737 | regional Pamlico mesh (bbox `(-77, 35)→(-75, 36)`) |
| `FESTUNG/FESTUNG` `swe/fortFiles/east.14` | 10 147 / 18 578 | **single shallow seamount node** at (-64.83, 32.36, depth 168 m) — no closed ring |
| `FESTUNG/FESTUNG` `swe/fortFiles/bahamas.14` | 926 / 1 696 | wrong projection (UTM-like grid coordinates) |

The `east.14` near-hit is informative: real WNAT-extent meshes do sample the Bermuda platform bathymetrically, but small pedagogical fixtures don't resolve it as an island. Topologically-Bermuda meshes only show up at HSOFS / EC2015 / EC95d resolution (≥31 K nodes), and those archives live on hosts I can't reach.

## What this PR adds

- **`scripts/diagnose_wnat_bermuda.py`** — reproducible verdict on any fort.14. Run with no args to test the committed fixture; pass a path to test any other.
- **`scripts/extract_boundary_only_fort14.py`** — slim-fixture extractor. Reads any upstream fort.14, derives boundary rings via topology, sorts by signed area (outer first, holes following), re-triangulates via `domain_from_polygon` at coarse `h_max`, writes a budget-friendly fort.14. Smoke-tested on `wnat_test.14` → 19.7 KB output (1 outer + 68 holes for Caribbean/Gulf coast).
- **`tests/fixtures/fort14/README.md`** — flag the Bermuda data limitation under the `wnat_test.14` provenance entry.

## What's needed to close #12

A higher-resolution upstream WNAT fort.14 that does carry Bermuda. Options I cannot self-serve from this sandbox:

1. **QuADMesh-MATLAB reference fixture** — the natural source per CLAUDE.md. Requires expanding my MCP scope to include `domattioli/QuADMesh-MATLAB`, OR pushing the largest of its fort.14 files to a scratch branch on `domattioli/admesh`.
2. **HSOFS / EC2015** — gigabytes; only practical via the slim-extractor in this PR.
3. **Hand-synthesized Bermuda hole** — drop a closed ring into the existing `wnat_test.14` for a regression-only fixture.

Once an upstream is in place, the extractor finishes the job in one command:

```bash
python scripts/extract_boundary_only_fort14.py upstream.14 \
    tests/fixtures/fort14/community/wnat_islands.14
```

Drafted because the fix path requires data I can't fetch unilaterally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoF4FRNz4zNVK2HJXGEtsL)_