### PR TITLE
Simplify badges to PyPI and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/admesh2D/"><img alt="PyPI" src="https://img.shields.io/pypi/v/admesh2D.svg?style=flat-square"></a>
-  <a href="https://github.com/domattioli/ADMESH/issues"><img alt="Issues" src="https://img.shields.io/github/issues/domattioli/ADMESH?style=flat-square"></a>
+  <img alt="Status" src="https://img.shields.io/badge/status-beta-yellow?style=flat-square">
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
   <img src="papers/fig8_admesh_wnat.png" alt="ADMESH mesh of the Western North Atlantic, Gulf of Mexico, and Caribbean Sea." width="100%">
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/admesh2D/"><img alt="PyPI" src="https://img.shields.io/pypi/v/admesh2D.svg?style=flat-square"></a>
+  <a href="https://github.com/domattioli/ADMESH/issues"><img alt="Issues" src="https://img.shields.io/github/issues/domattioli/ADMESH?style=flat-square"></a>
+</p>
+
 ---
 
 ## Install


### PR DESCRIPTION
Simplify README badges to show only PyPI and issues, removing Python version, license, GitHub link, status, and platform badges for a cleaner presentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5Pc3bSzpC9PDFhFoc5ncF)_