### PR TITLE
chore: DomI sync contract — lean CLAUDE.md, Article VIII, startup hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,19 +56,6 @@ upstream via `request-from-domi`; downstream is pull-only.
 
 ---
 
-## Stream Timeout Prevention
-
-1. Do each numbered task ONE AT A TIME. Complete one task fully,
-   confirm it worked, then move to the next.
-2. Never write a file longer than ~150 lines in a single tool call.
-   If a file will be longer, write it in multiple append/edit passes.
-3. Start a fresh session if the conversation gets long (20+ tool calls).
-   The error gets worse as the session grows.
-4. Keep individual grep/search outputs short. Use flags like
-   `--include` and `-l` (list files only) to limit output size.
-5. If you do hit the timeout, retry the same step in a shorter form.
-   Don't repeat the entire task from scratch.
-   
 ## Commands
 
 ```bash

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -176,7 +176,26 @@ pattern observed in session 0 (four `UNCONFIRMED_PAUSE` interrupts).
 
 ---
 
+## Article VIII — External Upstream (DomI)
+
+ADMESH is a downstream consumer of [`domattioli/DomI`](https://github.com/domattioli/DomI), which governs shared skills, MANIFEST, and cross-repo policy.
+
+1. `.domi-pin` (committed) records the upstream SHA + MANIFEST.md sha256. Never hand-edit; regenerate via `update_pin.sh`.
+2. `scripts/instructions_on_start.sh` hard-stops on drift (exit 1 or 3). Run `/sync-from-domi` before any write work when blocked.
+3. DomI skills take precedence over inline reimplementation. Submit changes upstream via `request-from-domi`; this repo is pull-only.
+4. DomI governs cross-repo skill lifecycle and issue closure. ADMESH's internal constitution (Articles I–VII) governs porting, workflow, and cadence.
+5. Publish gate: sync from DomI before any speckit branching, PyPI release, or fixture publication if drift is detected at session start.
+
+---
+
 ## Amendments log
+
+### 2026-05-08 — Article VIII adopted (external upstream governance)
+
+Added Article VIII — External Upstream (DomI). Codifies ADMESH as a
+downstream consumer of domattioli/DomI; establishes `.domi-pin`, startup
+hard-stop, and publish gate. Adopted as part of cross-repo DomI sync
+contract rollout.
 
 ### 2026-04-25 — Article VI rules 5–8 adopted (branch governance)
 

--- a/scripts/instructions_on_start.sh
+++ b/scripts/instructions_on_start.sh
@@ -1,90 +1,36 @@
 #!/bin/bash
-# instructions_on_start.sh — ADMESH session startup hook.
-#
-# Runs at the start of every Claude Code session in this repo. Validates
-# repo health and enforces the DomI sync contract before any write work.
-#
-# USAGE: bash "$(git rev-parse --show-toplevel)"/scripts/instructions_on_start.sh
-
+# scripts/instructions_on_start.sh — session startup health check
 set -euo pipefail
 
-# --- locate sync-from-domi ---
-# Search order:
-#   1. Plugin cache (after `claude plugin install sync-from-domi@DomI`)
-#      Path pattern: ~/.claude/plugins/cache/DomI/sync-from-domi/<version>/skills/sync-from-domi
-#   2. Plugin marketplace clone
-#   3. Vendored copy in this repo
-#   4. Global ~/.claude/skills
-DOMI_SKILL_PATH="${DOMI_SKILL_PATH:-}"
-if [ -z "$DOMI_SKILL_PATH" ]; then
-  # Glob-match the versioned cache path first (preferred)
-  for cached in "${HOME}"/.claude/plugins/cache/DomI/sync-from-domi/*/skills/sync-from-domi; do
-    if [ -f "${cached}/scripts/check_pin.sh" ]; then
-      DOMI_SKILL_PATH="$cached"
-      break
-    fi
-  done
-fi
-if [ -z "$DOMI_SKILL_PATH" ]; then
-  for candidate in \
-    "${HOME}/.claude/plugins/marketplaces/domattioli/DomI/plugins/sync-from-domi/skills/sync-from-domi" \
-    "./plugins/sync-from-domi/skills/sync-from-domi" \
-    "./skills/sync-from-domi" \
-    "${HOME}/.claude/skills/sync-from-domi"; do
-    if [ -f "${candidate}/scripts/check_pin.sh" ]; then
-      DOMI_SKILL_PATH="$candidate"
-      break
-    fi
-  done
-fi
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")" 
+cd "$REPO_ROOT" || exit 1
 
-if [ -z "$DOMI_SKILL_PATH" ] || [ ! -f "${DOMI_SKILL_PATH}/scripts/check_pin.sh" ]; then
-  echo "⚠ sync-from-domi skill not found locally; skipping DomI drift check"
-  echo "  → install via: claude plugin marketplace add domattioli/DomI && claude plugin install sync-from-domi@DomI"
-else
-  set +e
-  bash "${DOMI_SKILL_PATH}/scripts/check_pin.sh"
-  DOMI_DRIFT_RC=$?
-  set -e
+echo "=== Session Start: ADMESH ==="
+echo "Branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null) | Dirty: $(git status --porcelain 2>/dev/null | wc -l | tr -d ' ') files"
+echo ""
 
-  case $DOMI_DRIFT_RC in
-    0)
-      : # synced; continue
-      ;;
-    1)
-      echo ""
-      echo "============================================================"
-      echo "🛑 HARD STOP: downstream is BEHIND DomI"
-      echo "============================================================"
-      echo "Invoke the sync-from-domi skill before any write work:"
-      echo "  > sync from DomI"
-      echo "Or run manually:"
-      echo "  bash ${DOMI_SKILL_PATH}/scripts/update_pin.sh"
-      echo "  (then commit .domi-pin and any updated skills)"
-      echo "============================================================"
-      if [ "${DOMI_BLOCK_ON_DRIFT:-1}" = "1" ]; then
-        exit 1
-      fi
-      ;;
-    2)
-      echo "ⓘ First-time DomI pin needed; will create on next sync"
-      ;;
-    3)
-      echo ""
-      echo "============================================================"
-      echo "🛑 HARD STOP: DomI pin FORKED (manifest hash mismatch)"
-      echo "============================================================"
-      echo "Local edits to vendored DomI artifacts suspected."
-      echo "Operator must resolve manually before continuing."
-      echo "============================================================"
-      exit 1
-      ;;
-    4)
-      echo "⚠ DomI drift check skipped (gh unavailable); continuing"
-      ;;
+# DomI drift check (plugin cache → skills marketplace → vendored)
+_find_check_pin() {
+  for d in "$HOME/.claude/plugins/cache/DomI/sync-from-domi" \
+            "$HOME/.claude/skills/sync-from-domi" \
+            "$REPO_ROOT/plugins/sync-from-domi"; do
+    local f; f=$(find "$d" -name "check_pin.sh" -maxdepth 5 2>/dev/null | head -1)
+    [ -n "$f" ] && echo "$f" && return 0
+  done; return 1
+}
+
+CHECK_PIN=$(_find_check_pin 2>/dev/null || true)
+if [ -n "$CHECK_PIN" ]; then
+  set +e; bash "$CHECK_PIN"; rc=$?; set -e
+  case $rc in
+    0) echo "✓ DomI pin current" ;;
+    1|3) echo "HARD STOP: DomI drift (exit $rc). Run '/sync-from-domi' before write work." >&2; exit 1 ;;
+    2) echo "⚠ .domi-pin absent — run update_pin.sh to initialize" ;;
+    4) echo "⚠ gh unavailable — DomI drift check skipped" ;;
   esac
+else
+  echo "⚠ sync-from-domi not installed. Run: claude plugin install sync-from-domi@DomI"
 fi
-# --- end DomI drift check ---
+echo ""
 
-# --- repo health checks ---
-echo "✓ ADMESH startup checks complete"
+echo "=== ✓ Health check passed ==="


### PR DESCRIPTION
## Summary\n- `CLAUDE.md`: Removed generic \"Stream Timeout Prevention\" section (not repo-specific)\n- `CONSTITUTION.md`: Added Article VIII — External Upstream (DomI) + amendments log entry\n- `scripts/instructions_on_start.sh`: New startup health check with DomI drift gate\n\n## Test plan\n- [ ] Run `bash scripts/instructions_on_start.sh` — expect HEALTHY or drift warning\n- [ ] Verify `.domi-pin` presence (or warn-only if absent)\n- [ ] Confirm Article VIII appears before Amendments log in CONSTITUTION.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeV3rN57SdMTyWQEjDXbqb)_