### PR TITLE
docs: add Constitution Article VIII for DomI upstream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ block work. Unpinned state (exit code 2) is allowed for first-time setup.
 **MUST NOT** edit DomI-owned skills directly in this repo. Submit changes
 upstream via `request-from-domi`; downstream is pull-only.
 
+**Release skills come from DomI.** `github-release` and `pypi-publish` are
+maintained upstream and pulled in via `sync-from-domi`. Do not vendor or
+fork local copies — upstream owns the version that ships.
+
+**Orthogonal to Constitution Principle I.** The DomI sync contract governs
+the skill / policy layer only. Constitution Principle I (faithful port)
+still binds the 13 locked stage modules under `admesh/`. Skill drift never
+licenses changes to those modules; a faithful-port violation never excuses
+skipping a sync.
+
+**Routine session instructions** (paste verbatim into any scheduled
+routine targeting this repo):
+
+> Read https://raw.githubusercontent.com/domattioli/DomI/main/claude_routine_instructions.md
+> then CONSTITUTION.md → PROJECT_PLAN.md → CLAUDE.md.
+
 ---
 
 ## Stream Timeout Prevention

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -176,7 +176,37 @@ pattern observed in session 0 (four `UNCONFIRMED_PAUSE` interrupts).
 
 ---
 
+## Article VIII — External upstream (DomI)
+
+[`domattioli/DomI`](https://github.com/domattioli/DomI) is the upstream
+skill and policy provider for this repo.
+
+1. **`.domi-pin` must be committed and current.** It records the upstream
+   commit SHA and MANIFEST.md sha256 the repo is synced against.
+2. **Session start auto-checks drift.** `scripts/instructions_on_start.sh`
+   invokes the `sync-from-domi` drift check; the session HARD STOPs if
+   the pin is behind `domattioli/DomI@main` or the manifest hash forks.
+3. **DomI-provided skills take precedence over inline implementations.**
+   When DomI ships a skill (e.g. `github-release`, `pypi-publish`), this
+   repo consumes it via `sync-from-domi` rather than maintaining a local
+   copy. Local re-implementations of upstream-owned skills are forbidden.
+4. **Orthogonal to Article II Principle I.** This article governs the
+   skill / policy layer only. The faithful-port hard rule on the 13
+   locked stage modules under `admesh/` is unaffected — DomI sync never
+   licenses a stage-module change, and faithful-port work never excuses
+   skipping a DomI sync.
+
+---
+
 ## Amendments log
+
+### 2026-05-08 — Article VIII adopted (DomI external upstream)
+
+Adopted the DomI sync contract: `.domi-pin` ledger, session-start drift
+check via `sync-from-domi`, and upstream precedence for shared skills
+(`github-release`, `pypi-publish`). Explicitly orthogonal to Principle I
+(faithful port) so the two governance layers cannot be confused. Session
+reference: PR #52 (`claude/setup-domi-plugins-tGWnU`).
 
 ### 2026-04-25 — Article VI rules 5–8 adopted (branch governance)
 


### PR DESCRIPTION
Codify the DomI sync contract at the constitution level (Article VIII) and extend CLAUDE.md with release-skill upstream-precedence and the canonical routine session instructions. Article VIII is explicitly orthogonal to Principle I so faithful-port and skill-sync concerns cannot be conflated.