### PR TITLE
chore: enable DomI contract plugins via settings.json (DomI #114)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "DomI": {
+      "source": {
+        "source": "github",
+        "repo": "domattioli/DomI"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "sync-from-domi@DomI": true,
+    "request-from-domi@DomI": true,
+    "introspect@DomI": true
+  }
+}

--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: 32e46fcd85795eefe8ae1034bd43439b30bee5d6
+sha: 5ed87bf1175a1d0f299ee4bf72f8ff6de91ecf5a
 manifest_sha256: 1cf54750b719fde4e4ab92f93dee39da6fa66ab96e5b44c58c3ae533efcdcfa0
-pinned_at: 2026-05-25T02:59:57Z
+pinned_at: 2026-05-25T21:41:00Z


### PR DESCRIPTION
Minimal config-only activation of the DomI contract-plugin fix (DomI #114), off `main` to bypass the dirty rolling PR #105.

- `.claude/settings.json` — new; register DomI marketplace + enable the 3 contract plugins.
- `.domi-pin` — bump to DomI main `5ed87bf`.

Activates the fix on `main` so fresh containers load the plugins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUxttrJdTvwWHG71TY9Qyw)_