### PR TITLE
docs: daily-issue-fixing → daily-maintenance (md + sh)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,7 @@ Constitution Principle I: 13 faithful-port modules stay numerically identical. S
 ## Skills & Tools
 
 All Claude Code skills managed by parent **DomI** repository:
-- Single-branch policy enforcement (`daily-issue-fixing`)
+- Single-branch policy enforcement (`daily-maintenance`)
 - Pre-commit hooks
 - Session startup configuration
 

--- a/.claude/handoffs/2026-05-25-wnat-version-benchmark.md
+++ b/.claude/handoffs/2026-05-25-wnat-version-benchmark.md
@@ -1,6 +1,6 @@
 # Session Handoff: WNAT version-comparison benchmark + Performance README
 
-**Date:** 2026-05-25 **Project:** /home/user/ADMESH **Branch:** daily-issue-fixing (@30eb104)
+**Date:** 2026-05-25 **Project:** /home/user/ADMESH **Branch:** daily-maintenance (@30eb104)
 
 ## Current State
 
@@ -18,7 +18,7 @@ Built a version-agnostic per-stage timing harness, ran v0.2.1 (original Python) 
 - **Fixed niter=120 both runs** — isolates per-call cost; convergence-tuning benefit (ttol/dptol) deliberately excluded.
 - **Optimized code is still pure Python** — speedup = Numba-JIT uniform-grid SDF + Numba solve_iter, not C++.
 - **PR via curl+$GITHUB_TOKEN** — GitHub MCP OAuth endpoint was down (upstream connect error); used mcp-scope-preflight's documented api.github.com fallback.
-- **Commit target daily-issue-fixing** — operator-chosen (AskUserQuestion); where the optimization lives.
+- **Commit target daily-maintenance** — operator-chosen (AskUserQuestion); where the optimization lives.
 
 ## Code Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ See `TESTING.md` for the full marker reference and fixture-data layout.
 
 ## Branch contract
 
-- All in-progress work lives on `daily-issue-fixing`. Open issues directly
+- All in-progress work lives on `daily-maintenance`. Open issues directly
   against that branch; do not push directly to `main`.
 - Feature specs (`specs/NNN-name/`) may live on their own short-lived
-  `NNN-name` branches and merge back to `daily-issue-fixing` when complete.
+  `NNN-name` branches and merge back to `daily-maintenance` when complete.
 - Never push to `main` from a fork or local clone.
-- Never force-push to `main`, `daily-issue-fixing`, or any branch with an
+- Never force-push to `main`, `daily-maintenance`, or any branch with an
   open pull request from another contributor.
 - Never use `--no-verify`, `--no-gpg-sign`, or any other flag that skips
   configured git hooks unless explicitly approved by a maintainer in a
@@ -92,7 +92,7 @@ ships a new commit. Close the issue by running the sync.
 
 ## Pull requests
 
-- Target `daily-issue-fixing`, not `main`.
+- Target `daily-maintenance`, not `main`.
 - Mark as draft until CI is green.
 - Include a "Test plan" section in the body. If the PR is documentation-only,
   say so explicitly.

--- a/docs/HOOKS-AUDIT.md
+++ b/docs/HOOKS-AUDIT.md
@@ -4,7 +4,7 @@ Read-only audit of the ADMESH Claude Code hook footprint. Companion to
 `TEST-AUDIT.md`. Per issue [#61](https://github.com/domattioli/ADMESH/issues/61).
 
 **Audit date:** 2026-05-18
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 
 ## 1. Inventory
 

--- a/docs/PYPI_CLAIM_TASKS.md
+++ b/docs/PYPI_CLAIM_TASKS.md
@@ -132,7 +132,7 @@ Task 3 (Monitor)
 
 ✓ **Planning phase complete** when:
 - Email draft is reviewed and approved
-- CONTACT_LOG.md is committed to `daily-issue-fixing` branch
+- CONTACT_LOG.md is committed to `daily-maintenance` branch
 - Task breakdown is documented
 
 ✓ **Issue resolved** when:

--- a/docs/adr/ADR-001-chilmesh-boundary.md
+++ b/docs/adr/ADR-001-chilmesh-boundary.md
@@ -7,7 +7,7 @@
 | Snapshot date (CHILmesh inferred surface) | 2026-05-21 |
 | Spec | [spec 015 — chilmesh overlap analysis](../../specs/015-chilmesh-overlap-analysis/) |
 | Issue | [#81 overlap with chilmesh](https://github.com/domattioli/ADMESH/issues/81) |
-| Branch | `daily-issue-fixing` |
+| Branch | `daily-maintenance` |
 
 ## Context
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,13 +1,13 @@
 # Contributing
 
-See **[CONTRIBUTING.md](https://github.com/domattioli/ADMESH/blob/daily-issue-fixing/CONTRIBUTING.md)**
+See **[CONTRIBUTING.md](https://github.com/domattioli/ADMESH/blob/daily-maintenance/CONTRIBUTING.md)**
 at the repository root for the full contributor guide.
 
 ## Quick reference
 
 - Dev setup: `pip install -e ".[dev]"`
 - Tests: `pytest -m "not slow" -q`
-- Branch: all in-progress work on `daily-issue-fixing`; spec branches
+- Branch: all in-progress work on `daily-maintenance`; spec branches
   (`NNN-name`) for multi-commit features.
 - Never push to `main`; never force-push to a branch with an open PR;
   never `--no-verify`.

--- a/docs/governance/PROJECT_PLAN.md
+++ b/docs/governance/PROJECT_PLAN.md
@@ -6,13 +6,13 @@ Phased roadmap for porting `QuADMesh-MATLAB/01_ADMESH_Library` to Python. Govern
 
 ## Where we are today (2026-05-19, spec 012 background-grid-stage-tests planning COMPLETE)
 
-**Spec 012 (`specs/012-background-grid-stage-tests/`) planning shipped on `daily-issue-fixing`.**
+**Spec 012 (`specs/012-background-grid-stage-tests/`) planning shipped on `daily-maintenance`.**
 
 - Tracks issue #73 (TEST-AUDIT.md backlog B-05 / finding F-MED-01) — `admesh/_stages/background_grid.py` has no eponymous test file.
 - Planning surfaced that the canonical module is a 7-line stub; the original issue's parity-test proposal cannot satisfy at `atol=1e-10` until the MATLAB port lands.
 - Resolution: two-track spec. Track A (test scaffold + smoke + `xfail(strict=True)` parity scaffolds) closes the audit gap immediately without the port. Track B (numerical parity at `atol=1e-10`) gates on the new follow-up impl issue #78.
 - Issue #78 opened to track the actual port of `02_Create_Background_Grid/CreateBackgroundGrid.m`. Verified: `scripts/export_matlab_fixtures.m` does not yet export a stage-02 fixture (OQ-1 resolved → fixture work belongs to #78).
-- Constitution Principle I (numerical identity) cited in spec 012 §1 and issue #78. Branch policy: all work on `daily-issue-fixing`.
+- Constitution Principle I (numerical identity) cited in spec 012 §1 and issue #78. Branch policy: all work on `daily-maintenance`.
 - Spec 012 deliverables landing this run: `spec.md`, `plan.md`, `tasks.md`, issue #78, plus this PROJECT_PLAN entry. Track A implementation (T-012-2 / T-012-3) deferred to next run per the planning-mode mandate.
 
 ---
@@ -45,7 +45,7 @@ Phased roadmap for porting `QuADMesh-MATLAB/01_ADMESH_Library` to Python. Govern
   - `007-1d-boundary-seeding` (issue #2, in progress)
   - `008-gmsh-io-integration` (issue #5, planning)
 - ~20 ADMESH issues closed since the 2026-04-26 entry; issue #15 (right-isoceles smoother), #27 (valence balancing) and #36 (`distmesh2d` undefined `_boundary_cleanup`) are among the larger ones.
-- New "daily-issue-fixing" workflow adopted: one long-lived integration branch, no PR proliferation, autonomous routine driven by DomI skill marketplace. ADMESH consumes DomI v1.9 manifest (pinned at commit `ab5bb49e`, `manifest_sha256` recorded in `.domi-pin`).
+- New "daily-maintenance" workflow adopted: one long-lived integration branch, no PR proliferation, autonomous routine driven by DomI skill marketplace. ADMESH consumes DomI v1.9 manifest (pinned at commit `ab5bb49e`, `manifest_sha256` recorded in `.domi-pin`).
 - `TEST-AUDIT.md` shipped on 2026-05-15 (issue #59). Surfaced **F-CRIT-01**: only `publish.yml` exists, no CI workflow runs the 310 test functions. Sibling audit issues #60 (test surface, routes to DomI #63) and #61 (Claude Code hooks, routes to DomI #64) are open.
 - `admesh-domains>=0.1.0` is now a hard runtime dependency (`pyproject.toml:22`). The registry sibling is part of the public surface for 0.1.0.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ of the MATLAB reference and may evolve as the port is refined. See
 
 ## Project state
 
-- **Maturity**: pre-0.1.0; first PyPI tag tracked by [spec 009](https://github.com/domattioli/ADMESH/blob/daily-issue-fixing/specs/009-release-readiness-for-0.1.0/spec.md).
+- **Maturity**: pre-0.1.0; first PyPI tag tracked by [spec 009](https://github.com/domattioli/ADMESH/blob/daily-maintenance/specs/009-release-readiness-for-0.1.0/spec.md).
 - **License**: Apache-2.0.
 - **Repository**: [github.com/domattioli/ADMESH](https://github.com/domattioli/ADMESH).
 - **Sibling registry**: [github.com/domattioli/ADMESH-Domains](https://github.com/domattioli/ADMESH-Domains) — federated mesh metadata + HuggingFace-mirrored data files.

--- a/docs/planning/TASKS_005_GMSH_IO.md
+++ b/docs/planning/TASKS_005_GMSH_IO.md
@@ -190,8 +190,8 @@
 ---
 
 ### Task 10: Cleanup & merge
-**Objective**: Finalize code, commit, push to `daily-issue-fixing` branch  
-**Acceptance**: All commits are on `daily-issue-fixing`; PR is ready  
+**Objective**: Finalize code, commit, push to `daily-maintenance` branch  
+**Acceptance**: All commits are on `daily-maintenance`; PR is ready  
 **Depends on**: All tasks 1–9  
 **Owner**: Implementation phase  
 **Effort**: 15 minutes  
@@ -206,7 +206,7 @@
   - Commit 2: admesh/api.py + admesh/__init__.py
   - Commit 3: docs/ updates
 - [ ] Commit messages reference issue #5: `Resolve #5: Implement Gmsh I/O (Feature 003)`
-- [ ] Push to origin/daily-issue-fixing
+- [ ] Push to origin/daily-maintenance
 - [ ] Create PR (draft) if one doesn't exist
 
 ---

--- a/docs/planning/issue-57-tasks.md
+++ b/docs/planning/issue-57-tasks.md
@@ -15,7 +15,7 @@
 - [x] 1.9 Synthesize audit results (docs/planning/issue-57-audits.md)
 - [x] 1.10 Draft all 8 spec CONSTITUTION.md files
 - [x] 1.11 Create CONSTITUTION-FRAMEWORK.md
-- [x] 1.12 Commit planning artifacts to daily-issue-fixing
+- [x] 1.12 Commit planning artifacts to daily-maintenance
 
 ## Phase 2 (Implementation) — Complete
 
@@ -27,7 +27,7 @@
 - [x] 2.6 Finalize and commit specs/006/CONSTITUTION.md
 - [x] 2.7 Finalize and commit specs/007/CONSTITUTION.md
 - [x] 2.8 Finalize and commit specs/008/CONSTITUTION.md
-- [x] 2.9 Push all to daily-issue-fixing via GitHub MCP
+- [x] 2.9 Push all to daily-maintenance via GitHub MCP
 - [x] 2.10 Post issue comment and close #57
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -189,5 +189,5 @@ plt.show()
   for faithful-port discipline, no C extensions, and reference-test cadence.
 - **[Project plan](governance/PROJECT_PLAN.md)** — historical and current
   status; "Path to 0.1.0" lives at the top.
-- **[Contributing](https://github.com/domattioli/ADMESH/blob/daily-issue-fixing/CONTRIBUTING.md)** — dev setup, branch contract,
+- **[Contributing](https://github.com/domattioli/ADMESH/blob/daily-maintenance/CONTRIBUTING.md)** — dev setup, branch contract,
   filing issues.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-See **[TESTING.md](https://github.com/domattioli/ADMESH/blob/daily-issue-fixing/TESTING.md)**
+See **[TESTING.md](https://github.com/domattioli/ADMESH/blob/daily-maintenance/TESTING.md)**
 at the repository root for the full testing guide.
 
 ## Quick reference

--- a/docs/upstream/DOMI_SYNC_FROM_GH_DEPENDENCY.md
+++ b/docs/upstream/DOMI_SYNC_FROM_GH_DEPENDENCY.md
@@ -38,7 +38,7 @@ cleanly via `claude plugin install sync-from-domi@DomI`.
 
 ### Reproduction (ADMESH session 2026-05-15)
 
-1. Fresh remote Claude Code session, container cloned ADMESH at `daily-issue-fixing`.
+1. Fresh remote Claude Code session, container cloned ADMESH at `daily-maintenance`.
 2. `scripts/instructions_on_start.sh` reports `sync-from-domi not installed`.
 3. `claude plugin marketplace add domattioli/DomI` → success.
 4. `claude plugin install sync-from-domi@DomI` → success.

--- a/specs/006-verify-h-parameter-usage/impl_plan.md
+++ b/specs/006-verify-h-parameter-usage/impl_plan.md
@@ -3,7 +3,7 @@
 **Date**: 2026-05-06  
 **Status**: Planning Phase  
 **Issue Reference**: #37  
-**Branch**: `daily-issue-fixing` (mandate reuse)
+**Branch**: `daily-maintenance` (mandate reuse)
 
 ## Overview
 

--- a/specs/007-1d-boundary-seeding/plan.md
+++ b/specs/007-1d-boundary-seeding/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: 1D Boundary Seeding for Domain Path
 
-**Branch**: `daily-issue-fixing` | **Date**: 2026-05-07 | **Spec**: [spec.md](spec.md)
+**Branch**: `daily-maintenance` | **Date**: 2026-05-07 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `specs/007-1d-boundary-seeding/spec.md`
 
 ## Summary

--- a/specs/007-1d-boundary-seeding/spec.md
+++ b/specs/007-1d-boundary-seeding/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: 1D Distmesh Boundary Seeding
 
-**Feature Branch**: `daily-issue-fixing`
+**Feature Branch**: `daily-maintenance`
 **Created**: 2026-05-07
 **Status**: Draft
 **Issue**: #2

--- a/specs/007-1d-boundary-seeding/tasks.md
+++ b/specs/007-1d-boundary-seeding/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: 1D Boundary Seeding for Domain Path
 
-**Issue**: #2 | **Branch**: `daily-issue-fixing`
+**Issue**: #2 | **Branch**: `daily-maintenance`
 
 ## Phase 1: Setup
 - [x] T001 Baseline verification

--- a/specs/008-gmsh-io-integration/plan.md
+++ b/specs/008-gmsh-io-integration/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Gmsh `.msh` I/O Integration
 
-**Branch**: `008-gmsh-io-integration` (logical; physical work lands on `daily-issue-fixing`)
+**Branch**: `008-gmsh-io-integration` (logical; physical work lands on `daily-maintenance`)
 **Date**: 2026-05-10
 **Spec**: [spec.md](./spec.md)
 **Tracks**: domattioli/ADMESH#5

--- a/specs/009-release-readiness-for-0.1.0/spec.md
+++ b/specs/009-release-readiness-for-0.1.0/spec.md
@@ -97,7 +97,7 @@ A downstream library author wants to depend on `admesh2D` and needs to know: whi
 
 - **FR-001**: `scripts/pre_tag_check.sh` MUST verify that `pyproject.toml` `[project].version` equals `admesh/__init__.py::__version__`, exiting non-zero with both file paths and conflicting values when they differ.
 - **FR-002**: `scripts/pre_tag_check.sh` MUST verify that `docs/governance/PROJECT_PLAN.md` contains a `## Where we are today (YYYY-MM-DD` entry whose date is within 30 days of `git log -1 --format=%cI` on HEAD, exiting non-zero with a `PLAN_STALE` message when stale.
-- **FR-003**: `docs/governance/PROJECT_PLAN.md` MUST gain a 2026-05-15 (or later) "Where we are today" entry capturing: closure of #11, addition of specs 003–008, daily-issue-fixing workflow adoption, DomI v1.9 sync state, audit issues #59/#60/#61, and an explicit pointer to this spec as the active sub-plan for 0.1.0.
+- **FR-003**: `docs/governance/PROJECT_PLAN.md` MUST gain a 2026-05-15 (or later) "Where we are today" entry capturing: closure of #11, addition of specs 003–008, daily-maintenance workflow adoption, DomI v1.9 sync state, audit issues #59/#60/#61, and an explicit pointer to this spec as the active sub-plan for 0.1.0.
 - **FR-004**: A `pytest --cov=admesh --cov-report=json --cov-report=term-missing` run output and a `pytest --durations=10` run output MUST be committed under `output/` and referenced from `TEST-AUDIT.md` (closes backlog items B-04 and B-06).
 - **FR-005**: `scripts/pre_tag_check.sh` MUST verify that `output/coverage.json` and `output/durations.txt` exist and were generated within 30 days of HEAD.
 - **FR-006**: Reconcile the version strings: `pyproject.toml` and `admesh/__init__.py::__version__` MUST both declare `0.1.0` (or whatever the agreed initial tag) at the moment R4 fires.
@@ -106,7 +106,7 @@ A downstream library author wants to depend on `admesh2D` and needs to know: whi
 
 - **FR-010**: A new `.github/workflows/tests.yml` MUST run the full pytest suite on every push and PR to any branch, on Python 3.10 / 3.11 / 3.12, on `ubuntu-latest`. This closes TEST-AUDIT finding F-CRIT-01.
 - **FR-011**: Tests requiring real coastal fixtures or external binaries MUST be marked with a `slow` pytest marker; the standard CI lane skips `slow`; a separate weekly lane (`.github/workflows/tests-slow.yml`) runs the full suite including `slow`.
-- **FR-012**: `CONTRIBUTING.md` MUST exist at repo root and cover: dev setup (`pip install -e ".[dev]"`), running tests (`pytest`), the `daily-issue-fixing` branch contract, the DomI sync expectation (`.domi-pin` ledger), and how to file an issue.
+- **FR-012**: `CONTRIBUTING.md` MUST exist at repo root and cover: dev setup (`pip install -e ".[dev]"`), running tests (`pytest`), the `daily-maintenance` branch contract, the DomI sync expectation (`.domi-pin` ledger), and how to file an issue.
 - **FR-013**: `TESTING.md` MUST exist (repo root or `docs/`) and cover: pytest invocation patterns, markers (`slow`, `requires_matlab`, `requires_chilmesh`), fixture-data locations, and the parity-tests pattern (port-correctness vs. MATLAB fixtures).
 - **FR-014**: `docs/ADMESH_DOMAINS_CONTRACT.md` MUST exist and document: the exact symbols ADMESH imports from `admesh-domains`, the supported version range, the parity-test mechanism, and the upgrade policy when `admesh-domains` ships a minor or major bump.
 - **FR-015**: `pyproject.toml` `[project].dependencies` MUST pin `admesh-domains>=0.1.0,<0.2` (or whatever upper bound the contract doc justifies).
@@ -118,7 +118,7 @@ A downstream library author wants to depend on `admesh2D` and needs to know: whi
 - **FR-021**: If the amendment passes, the package MUST be reorganized such that all faithful-port stage modules (`background_grid`, `bathymetry`, `boundary`, `curvature`, `distance`, `distmesh`, `dominate_tide`, `in_polygon`, `inpaint`, `medial_axis`, `mesh_size`, `quality`, `routine`) live under `admesh/_stages/`, with stub re-exports preserving backward compatibility on the old import paths until 1.0.
 - **FR-022**: If the amendment fails, `admesh/__init__.py::__all__` MUST be split into clearly commented "public surface" and "faithful-port stage modules (internal)" groups.
 - **FR-023**: A `docs/` subdirectory MUST house a mkdocs-material configuration (`mkdocs.yml`) covering: index page, quickstart, public API reference (auto-generated from docstrings via `mkdocstrings`), the porting-notes journal, and the constitution.
-- **FR-024**: GitHub Pages MUST serve the rendered docs from the `gh-pages` branch on every push to `daily-issue-fixing` and `main`, via a new `.github/workflows/docs.yml`.
+- **FR-024**: GitHub Pages MUST serve the rendered docs from the `gh-pages` branch on every push to `daily-maintenance` and `main`, via a new `.github/workflows/docs.yml`.
 - **FR-025**: Every public-surface symbol (`Mesh`, `Domain`, `triangulate`, `read_fort14`, `write_fort14`, `BoundaryType`, `BoundarySegment`, `Fort14ParseError`, `compose_size_field`, `SizeFieldFn`, `load_domain_from_fort14`, `load_domain_from_json`, `load_domain_from_toml`, `load_domain_from_registry`, `load_domain_with_metadata`, `list_available_domains`, `mesh_quality`, `right_iso_quality`, `smooth_for_quadrangulation`, `balance_valence_triangles`, `compute_valence`, `get_valence_report`, `BalanceConfig`, `BalanceResult`, `ValenceStats`) MUST have a complete docstring with `Parameters`, `Returns`, and at least one runnable example.
 
 #### Phase R4 — Issue #10 resolution + tag
@@ -146,7 +146,7 @@ A downstream library author wants to depend on `admesh2D` and needs to know: whi
 
 ### Measurable Outcomes
 
-- **SC-001**: `bash scripts/pre_tag_check.sh` exits zero on the `daily-issue-fixing` branch HEAD before the tag is pushed, and a deliberately-introduced version mismatch (test) causes it to exit non-zero.
+- **SC-001**: `bash scripts/pre_tag_check.sh` exits zero on the `daily-maintenance` branch HEAD before the tag is pushed, and a deliberately-introduced version mismatch (test) causes it to exit non-zero.
 - **SC-002**: `pip install admesh2D==0.1.0` in a fresh Python 3.10 / 3.11 / 3.12 virtualenv installs cleanly on Linux (and on macOS + Windows when validated by the weekly slow lane).
 - **SC-003**: 100% of public-surface symbols (per FR-025) have a docstring containing `Parameters`, `Returns`, and ≥1 runnable example; verified by a `tests/test_docstring_completeness.py`.
 - **SC-004**: CI test workflow runs all 310 test functions on every PR; a contributor opening a PR that fails any test sees the failure inline on the GitHub PR check, with median CI wall-clock under 8 minutes on the standard lane.
@@ -163,7 +163,7 @@ A downstream library author wants to depend on `admesh2D` and needs to know: whi
 - mkdocs-material is acceptable as the docs framework; sphinx is not a hard requirement and revisiting is allowed at 1.0.
 - GitHub Pages / Actions are the deployment substrate; no alternative hosting (ReadTheDocs) is required for 0.1.0.
 - The existing single-CI-workflow constraint is acceptable to expand: this spec adds 3 new workflows (`tests.yml`, `tests-slow.yml`, `docs.yml`) on top of the existing `publish.yml`.
-- The `daily-issue-fixing` branch remains the integration branch; this spec lives on `009-release-readiness-for-0.1.0` and merges back to `daily-issue-fixing` only after all four phases complete or are explicitly deferred.
+- The `daily-maintenance` branch remains the integration branch; this spec lives on `009-release-readiness-for-0.1.0` and merges back to `daily-maintenance` only after all four phases complete or are explicitly deferred.
 - Real coastal fixtures (`wnat_test.14`, `wetting_and_drying_test.14`) remain committed under `tests/fixtures/` and are acceptable as Tier-1/Tier-2 release-gate test data.
 - chilmesh integration remains a gated compat smoke test; no runtime dependency on `chilmesh` is introduced by this spec.
 

--- a/specs/009-release-readiness-for-0.1.0/tasks.md
+++ b/specs/009-release-readiness-for-0.1.0/tasks.md
@@ -63,7 +63,7 @@
 
 ### R2 — onboarding docs
 
-- [ ] T013 [P] [US3] Write `CONTRIBUTING.md` at repo root covering: (1) dev setup `git clone` + `pip install -e ".[dev]"`; (2) running tests `pytest -m "not slow" -q`; (3) branch contract — all work on `daily-issue-fixing`, no direct push to `main`; (4) DomI sync expectation — `.domi-pin` must match DomI HEAD before starting a write session; (5) how to file an issue (ADMESH or DomI).
+- [ ] T013 [P] [US3] Write `CONTRIBUTING.md` at repo root covering: (1) dev setup `git clone` + `pip install -e ".[dev]"`; (2) running tests `pytest -m "not slow" -q`; (3) branch contract — all work on `daily-maintenance`, no direct push to `main`; (4) DomI sync expectation — `.domi-pin` must match DomI HEAD before starting a write session; (5) how to file an issue (ADMESH or DomI).
 - [ ] T014 [P] [US3] Write `TESTING.md` at repo root covering: (1) pytest invocation patterns (standard, full, single file, single test, cov); (2) markers: `slow` (deselect by default), `requires_matlab` (MATLAB fixture skip), `requires_chilmesh` (chilmesh skip); (3) fixture-data locations under `tests/fixtures/`; (4) parity-test pattern (port-correctness tests vs. MATLAB golden fixtures); (5) the `assert_structurally_valid` helper in `tests/_structural_validity.py`.
 
 ### R2 — admesh-domains contract
@@ -109,7 +109,7 @@
 - [ ] T031 [US4] Write `mkdocs.yml` at repo root: `site_name: ADMESH`, nav covering index / quickstart / api-reference / porting-notes / constitution; `theme: material`; `plugins: [search, mkdocstrings]`.
 - [ ] T032 [P] [US4] Write `docs/index.md` (project overview, install, 3-line quickstart, links to API ref and porting notes).
 - [ ] T033 [P] [US4] Write `docs/quickstart.md` (end-to-end worked example: polygon → `triangulate` → `mesh.to_fort14`; plus round-trip with a real ADCIRC fixture; plus custom size-field contribution pattern).
-- [ ] T034 [US4] Write `.github/workflows/docs.yml`: steps checkout, setup-python, `pip install -e ".[dev]"`, `mkdocs gh-deploy --force`; triggers on push to `daily-issue-fixing` and `main`.
+- [ ] T034 [US4] Write `.github/workflows/docs.yml`: steps checkout, setup-python, `pip install -e ".[dev]"`, `mkdocs gh-deploy --force`; triggers on push to `daily-maintenance` and `main`.
 
 **Checkpoint**: `mkdocs build` succeeds locally; `mkdocs serve` shows the API reference page with all public symbols documented.
 

--- a/specs/010-registry-rewrite-for-admesh-domains-0.3/spec.md
+++ b/specs/010-registry-rewrite-for-admesh-domains-0.3/spec.md
@@ -2,7 +2,7 @@
 
 **Status**: Planning
 **Tracks**: [#64](https://github.com/domattioli/ADMESH/issues/64)
-**Branch**: `daily-issue-fixing` (no new branch — per CORE MANDATE)
+**Branch**: `daily-maintenance` (no new branch — per CORE MANDATE)
 **Severity**: high · **Type**: bug · **Scope**: integration
 **Companion**: spec 009 R2 (contract surface), `docs/ADMESH_DOMAINS_CONTRACT.md`
 

--- a/specs/010-registry-rewrite-for-admesh-domains-0.3/tasks.md
+++ b/specs/010-registry-rewrite-for-admesh-domains-0.3/tasks.md
@@ -45,7 +45,7 @@ Each task is independently testable. Dependencies ordered top-down.
 
 - **Tasks T010-1..T010-7** — source-of-truth edits (adapter rewrite +
   contract-doc update). Shipped in commit `05fd02d` on
-  `daily-issue-fixing` (PR #72).
+  `daily-maintenance` (PR #72).
 - **Tasks T010-8..T010-13** — offline test surface and full local
   validation. Shipped in the same commit. Offline `pytest -q -m
   "not slow"` exit 0 (361 passed, 12 expected skips, 3 slow

--- a/specs/011-annulus-meshing-animation/spec.md
+++ b/specs/011-annulus-meshing-animation/spec.md
@@ -2,7 +2,7 @@
 
 **Status**: Planning
 **Tracks**: [#70](https://github.com/domattioli/ADMESH/issues/70)
-**Branch**: `daily-issue-fixing` (no new branch — per CORE MANDATE)
+**Branch**: `daily-maintenance` (no new branch — per CORE MANDATE)
 **Severity**: medium · **Type**: documentation · **Scope**: docs + scripts
 
 ## 1. Problem statement

--- a/specs/011-annulus-meshing-animation/tasks.md
+++ b/specs/011-annulus-meshing-animation/tasks.md
@@ -32,7 +32,7 @@
   spec ships **planning artifacts** in the current run (per CORE
   MANDATE). The implementation tasks live as a follow-up "implement
   spec 011" comment on issue #70 and execute in a subsequent session
-  on the same `daily-issue-fixing` branch.
+  on the same `daily-maintenance` branch.
 - T011-9 is optional — the script being checked in is itself the
   guard against artifact drift; a unit test that asserts the GIF
   exists is belt-and-braces.

--- a/specs/012-background-grid-stage-tests/plan.md
+++ b/specs/012-background-grid-stage-tests/plan.md
@@ -1,7 +1,7 @@
 # Plan 012 — Direct stage tests for `admesh._stages.background_grid`
 
 **Spec**: `specs/012-background-grid-stage-tests/spec.md`
-**Branch**: `daily-issue-fixing`
+**Branch**: `daily-maintenance`
 **Phase**: Planning (no code commits this run)
 
 ## 1. Architecture decisions
@@ -67,7 +67,7 @@ hide indefinitely behind the larger port effort.
 ```
 Spec 012 (this run)
     │
-    ├── Track A (next implementation run on daily-issue-fixing)
+    ├── Track A (next implementation run on daily-maintenance)
     │     ├── T-012-1  Verify fixture exporter state
     │     ├── T-012-2  Create test scaffold (smoke + xfail parity)
     │     ├── T-012-3  Update TEST-AUDIT.md (F-MED-01, B-05)
@@ -92,7 +92,7 @@ Track A is one implementation run. Track B is gated on a separate spec.
   produced from a polygon or fort.14 input; the registry sibling has
   no role here.
 - **CHILMESH**: not involved.
-- **DomI**: spec uses the daily-issue-fixing workflow conventions
+- **DomI**: spec uses the daily-maintenance workflow conventions
   established by spec 009 / 010 / 011 (linked branch, audit gates,
   Constitution Principle I citation).
 

--- a/specs/012-background-grid-stage-tests/spec.md
+++ b/specs/012-background-grid-stage-tests/spec.md
@@ -2,7 +2,7 @@
 
 **Status**: Planning
 **Tracks**: [#73](https://github.com/domattioli/ADMESH/issues/73)
-**Branch**: `daily-issue-fixing` (no new branch — per CORE MANDATE)
+**Branch**: `daily-maintenance` (no new branch — per CORE MANDATE)
 **Severity**: low · **Type**: enhancement · **Scope**: tests
 **Companion**: `TEST-AUDIT.md` backlog item B-05 (finding F-MED-01)
 
@@ -135,7 +135,7 @@ passing without `xfail`.
 - [x] Follow-up implementation issue opened, linked from spec 012
       (issue #78, opened 2026-05-19).
 - [ ] No code under `admesh/` is modified.
-- [ ] All work lands on `daily-issue-fixing`.
+- [ ] All work lands on `daily-maintenance`.
 
 ## 6. Risks and mitigations
 

--- a/specs/012-background-grid-stage-tests/tasks.md
+++ b/specs/012-background-grid-stage-tests/tasks.md
@@ -2,7 +2,7 @@
 
 **Spec**: `specs/012-background-grid-stage-tests/spec.md`
 **Plan**: `specs/012-background-grid-stage-tests/plan.md`
-**Branch**: `daily-issue-fixing`
+**Branch**: `daily-maintenance`
 
 Atomic, testable, ordered. Each task is tied to a spec acceptance
 criterion (AC) and/or a plan section.
@@ -129,7 +129,7 @@ T-012-6 ─┴─► T-012-7        │
   `atol=1e-10` against MATLAB-exported fixtures, matching the
   precedent set in spec 002 / spec 009.
 - **Principle II (no branch proliferation)**: all tasks land on
-  `daily-issue-fixing`.
+  `daily-maintenance`.
 - **Principle III (audit gates close)**: T-012-3 explicitly closes
   the F-MED-01 / B-05 entries in `TEST-AUDIT.md`.
 

--- a/specs/013-background-grid-impl/plan.md
+++ b/specs/013-background-grid-impl/plan.md
@@ -1,7 +1,7 @@
 # Plan 013 — Implementation plan for background-grid port
 
 **Spec**: `specs/013-background-grid-impl/spec.md`
-**Branch**: `daily-issue-fixing`
+**Branch**: `daily-maintenance`
 
 ## Approach
 
@@ -190,7 +190,7 @@ regression cause recorded.
 
 - **Constitution Principle I**: enforced by FR-013-2 / FR-013-6.
 - **Principle II (no branch proliferation)**: all passes on
-  `daily-issue-fixing`.
+  `daily-maintenance`.
 - **Principle III (audit gates close)**: F-MED-01 / B-05 close once
   Pass 5b finishes.
 

--- a/specs/013-background-grid-impl/spec.md
+++ b/specs/013-background-grid-impl/spec.md
@@ -3,7 +3,7 @@
 **Status**: Planning
 **Tracks**: [#78](https://github.com/domattioli/ADMESH/issues/78)
 **Companion**: [#73](https://github.com/domattioli/ADMESH/issues/73) (gap report); spec 012 (test contract)
-**Branch**: `daily-issue-fixing` (no new branch — per CORE MANDATE)
+**Branch**: `daily-maintenance` (no new branch — per CORE MANDATE)
 **Severity**: medium · **Type**: port · **Scope**: numerics
 **Constitution**: Principle I (MATLAB-numerical-identity) binds this port at `atol=1e-10`.
 

--- a/specs/013-background-grid-impl/tasks.md
+++ b/specs/013-background-grid-impl/tasks.md
@@ -2,7 +2,7 @@
 
 **Spec**: `specs/013-background-grid-impl/spec.md`
 **Plan**: `specs/013-background-grid-impl/plan.md`
-**Branch**: `daily-issue-fixing`
+**Branch**: `daily-maintenance`
 
 Atomic, testable, ordered. Each task ties to a spec acceptance
 criterion (AC) and/or a plan pass.
@@ -35,7 +35,7 @@ criterion (AC) and/or a plan pass.
 - **Owner**: current run
 - **Inputs**: spec 013 URL
 - **Action**: Post a comment on #78 stating "Planning complete —
-  spec 013 landed on `daily-issue-fixing`. Implementation in a
+  spec 013 landed on `daily-maintenance`. Implementation in a
   follow-up run; resolves OQ-1..OQ-4 first." Link to spec / plan /
   tasks.
 - **Outputs**: comment posted.
@@ -177,7 +177,7 @@ T-013-B1 ─► T-013-B2 ─► T-013-B3 ─► T-013-B4
   enforce `atol=1e-10` against MATLAB fixture, matching the
   precedent of spec 002 / 009.
 - **Principle II (no branch proliferation)**: all tasks land on
-  `daily-issue-fixing`.
+  `daily-maintenance`.
 - **Principle III (audit gates close)**: T-013-B6 closes the
   Track B half of spec 012's audit ledger; #73 closes
   transitively when #78 closes.
@@ -190,4 +190,4 @@ T-013-B1 ─► T-013-B2 ─► T-013-B3 ─► T-013-B4
 - [ ] Comment on issue #78 — planning complete
 - [ ] Comment on issue #73 — cross-link
 - [ ] PROJECT_PLAN.md updated (if index exists)
-- [ ] Commit + push planning artifacts to `daily-issue-fixing`
+- [ ] Commit + push planning artifacts to `daily-maintenance`

--- a/specs/014-issue-templates/plan.md
+++ b/specs/014-issue-templates/plan.md
@@ -2,7 +2,7 @@
 
 **Spec**: `specs/014-issue-templates/spec.md`
 **Resolves**: ADMESH #83
-**Branch**: `daily-issue-fixing` (single rolling branch per CLAUDE.md routine)
+**Branch**: `daily-maintenance` (single rolling branch per CLAUDE.md routine)
 
 ## Architecture decisions
 
@@ -125,7 +125,7 @@ No reverse coupling — DomI doesn't read ADMESH templates.
 1. **T-014-1**: Audit current labels against required set. ✓
 2. **T-014-2**: Write `config.yml`. ✓
 3. **T-014-3..6**: Write four template YAMLs. ✓
-4. **T-014-7**: Commit on `daily-issue-fixing` (via MCP API push, container's
+4. **T-014-7**: Commit on `daily-maintenance` (via MCP API push, container's
    local git signing failed). ✓
 5. **T-014-8**: Close issue with a comment listing label gaps for maintainer
    follow-up.

--- a/specs/014-issue-templates/spec.md
+++ b/specs/014-issue-templates/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: GitHub Issue Templates for ADMESH
 
-**Feature Branch**: `daily-issue-fixing` (no per-spec branch; per CLAUDE.md routine)
+**Feature Branch**: `daily-maintenance` (no per-spec branch; per CLAUDE.md routine)
 **Created**: 2026-05-20
 **Status**: Draft
 **Resolves**: [#83](https://github.com/domattioli/ADMESH/issues/83)
@@ -54,7 +54,7 @@ That divergence has concrete downstream cost:
 
 ### User Story 1 — File a bug against a port-stage module (Priority: P1)
 
-A user (or a future automated agent like CHILmesh's daily-issue-fixing routine)
+A user (or a future automated agent like CHILmesh's daily-maintenance routine)
 hits a numerical-identity regression in `admesh/_stages/curvature.py` against the
 MATLAB reference. They click "New issue" → "Bug Report" → fill in:
 - Affected module / stage (input)
@@ -173,7 +173,7 @@ the spec, per the CLAUDE.md routine's STEP 6 implementation branch.
       (verified post-merge).
 - [x] Each template's auto-applied labels match labels that already exist
       on the repo (no silent-drop failures); gaps surfaced in closure comment.
-- [x] Spec, plan, tasks land on `daily-issue-fixing`; commit references #83.
+- [x] Spec, plan, tasks land on `daily-maintenance`; commit references #83.
 
 ## Out of Scope
 

--- a/specs/014-issue-templates/tasks.md
+++ b/specs/014-issue-templates/tasks.md
@@ -81,7 +81,7 @@ the #25-style boilerplate), adjacent issues (input, optional).
 
 **Dependency**: T-014-2.
 
-### T-014-7 — Commit on `daily-issue-fixing` ✓
+### T-014-7 — Commit on `daily-maintenance` ✓
 
 **Tied to**: CLAUDE.md routine → STEP 7 (Validation & Commit).
 
@@ -91,7 +91,7 @@ GitHub's verified signature flow. Templates committed in
 `afa69e978c96e0288a163a568022ba29badf5c27`; spec/plan/tasks
 follow-on in subsequent `create_or_update_file` commits.
 
-**Verification**: branch HEAD on `daily-issue-fixing` shows the
+**Verification**: branch HEAD on `daily-maintenance` shows the
 template-bundle commit referencing #83.
 
 ### T-014-8 — Close issue with label-gap punch list

--- a/specs/015-chilmesh-overlap-analysis/plan.md
+++ b/specs/015-chilmesh-overlap-analysis/plan.md
@@ -72,7 +72,7 @@ Post a single comment on issue #81 with:
 - Link to ADR-001
 - The disposition table (markdown)
 - List of follow-up issue numbers
-- Recommendation: close #81 once ADR is merged to `daily-issue-fixing`.
+- Recommendation: close #81 once ADR is merged to `daily-maintenance`.
 
 ## Architectural decisions to record up-front
 

--- a/specs/015-chilmesh-overlap-analysis/spec.md
+++ b/specs/015-chilmesh-overlap-analysis/spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Planning-phase only. No code shipping.
 **Issue:** [#81 overlap with chilmesh](https://github.com/domattioli/ADMESH/issues/81)
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 **Token budget:** MEDIUM (architecture audit, doc-only deliverables)
 
 ---

--- a/specs/015-chilmesh-overlap-analysis/tasks.md
+++ b/specs/015-chilmesh-overlap-analysis/tasks.md
@@ -63,4 +63,4 @@ Dependencies: G requires all of A–F complete.
 
 ## Definition of done
 
-All tasks above checked off, AC1–AC7 satisfied, follow-up issue numbers recorded in ADR-001, closing comment posted on #81. Branch `daily-issue-fixing` has new commits scoped to spec 015 files only — zero changes outside `specs/015-*/`, `docs/adr/`, and the single CLAUDE.md / README.md line.
+All tasks above checked off, AC1–AC7 satisfied, follow-up issue numbers recorded in ADR-001, closing comment posted on #81. Branch `daily-maintenance` has new commits scoped to spec 015 files only — zero changes outside `specs/015-*/`, `docs/adr/`, and the single CLAUDE.md / README.md line.

--- a/specs/016-user-configurable-max-valence/spec.md
+++ b/specs/016-user-configurable-max-valence/spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Planning-phase only. No code shipping in this commit.
 **Issue:** [#84 the admesh algorithm should allow users to set a max-valence for vertices](https://github.com/domattioli/ADMESH/issues/84)
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 **Token budget:** SMALL (single dataclass field + one gate condition + 3 tests)
 
 ---

--- a/specs/016-user-configurable-max-valence/tasks.md
+++ b/specs/016-user-configurable-max-valence/tasks.md
@@ -2,7 +2,7 @@
 
 **Spec:** [spec.md](./spec.md) · **Plan:** [plan.md](./plan.md)
 **Issue:** [#84](https://github.com/domattioli/ADMESH/issues/84)
-**Branch (when implementing):** `daily-issue-fixing`
+**Branch (when implementing):** `daily-maintenance`
 
 Each task is atomic, testable, and references the acceptance criterion
 it satisfies. Tasks marked `[planning]` are complete with this commit.

--- a/specs/017-default-size-field-stack/spec.md
+++ b/specs/017-default-size-field-stack/spec.md
@@ -3,7 +3,7 @@
 **Status:** Planning-phase only. No code shipping in this commit.
 **Issue:** [#65 Wire default size-field stack in triangulate() (3-step plan from #10) — fresh-mesh quality improvement](https://github.com/domattioli/ADMESH/issues/65)
 **Related:** [#10](https://github.com/domattioli/ADMESH/issues/10) (original report, retained for the quality concern; closes on #65 merge)
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 **Target:** post-0.1.0 (0.2.0 scope)
 **Token budget:** MEDIUM (1 dataclass field, 2 callsite edits, 4 acceptance tests already-green, 1 new bathymetry-path test, 1 visual gate, ~6 unit tests)
 

--- a/specs/018-boundary-tri-pair-degeneracy/spec.md
+++ b/specs/018-boundary-tri-pair-degeneracy/spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Planning-phase only. No code shipping.
 **Issue:** [#85 Cross-repo tracker: boundary tri-pair degeneracy (CHILmesh-side post-admesh protocol)](https://github.com/domattioli/ADMESH/issues/85)
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 **Token budget:** SMALL (analytical investigation + disposition write-up; no fixtures generated, no code in `admesh/`).
 
 ---

--- a/specs/020-wnat-benchmark-quality/spec.md
+++ b/specs/020-wnat-benchmark-quality/spec.md
@@ -3,7 +3,7 @@
 **Status:** Planning-phase only. No code shipping in this commit (ADMESH planning profile).
 **Issue:** [#101 wnat mesh for the benchmark has far too many low quality elements](https://github.com/domattioli/ADMESH/issues/101) — `priority: critical`, `Executive: Approved`, `status: ready`.
 **Related:** [#65](https://github.com/domattioli/ADMESH/issues/65) / spec-017 (wire default size-field stack in `triangulate()`), [#86](https://github.com/domattioli/ADMESH/issues/86) (C++/Rust port), [#8](https://github.com/domattioli/ADMESH/issues/8) (size-field acceleration), PR [#103](https://github.com/domattioli/ADMESH/pull/103) (C++ distmesh — separate branch, does **not** address this).
-**Branch:** `daily-issue-fixing`
+**Branch:** `daily-maintenance`
 **Target:** code-shipping session (this spec is the contract; implementation is out of scope here).
 **Token budget:** SMALL–MEDIUM (1 worker rewrite + 1 regression test + 1 driver touch).
 
@@ -13,7 +13,7 @@
 
 The WNAT version-comparison benchmark reports far too many low-quality / near-degenerate triangles. With params derived from `wnat_test.14` (hmin=0.119, hmax=0.967, g=0.209) the benchmark mesh hits `min_q=0.023` — well below the production floor — and its quality distribution does not match the WNAT (Onur/Hagen) source. The production `triangulate()` path yields WNAT `mean_q≈0.93`.
 
-## 2. Root cause (grounded in current `daily-issue-fixing` code)
+## 2. Root cause (grounded in current `daily-maintenance` code)
 
 The benchmark is a per-stage **timing** harness that bypasses `admesh.triangulate()` and calls locked stage modules directly with a **mis-parameterized, simplified size field**:
 


### PR DESCRIPTION
Rename `daily-issue-fixing` → `daily-maintenance` across active md + sh (42 files; excludes history: introspections/sessions/_archive/CHANGELOG). Fleet-wide branch rename per DomI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcRoYtcPC2FdTBLETu2vZw)_