### PR TITLE
policy: dispatch all coding to a Haiku subagent by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,3 +85,11 @@ All Claude Code skills managed by parent **DomI** repository:
 - Session startup configuration
 
 Skill updates → https://github.com/domattioli/DomI
+
+## Coding dispatch — Haiku subagent default
+
+All coding work (writing or editing source code) MUST be dispatched to a subagent running the Haiku model (`claude-haiku-4-5`) — not written inline by the main session. The orchestrator session plans, reviews, and integrates; implementation is delegated to the Haiku subagent.
+
+- **Default**: for any code-writing/editing task, spawn a subagent with `model: haiku`.
+- **Exception**: only when the operator explicitly directs otherwise (e.g. "do it inline", "use Sonnet/Opus for this"). Explicit operator instruction only — never assumed.
+- **Scope**: applies to code. Non-coding work (planning, research, docs, git/PR orchestration, review) stays on the main session.


### PR DESCRIPTION
Adds the fleet Haiku-dispatch policy to `.claude/CLAUDE.md`: coding delegated to a `claude-haiku-4-5` subagent by default; exception only on explicit operator direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcRoYtcPC2FdTBLETu2vZw)_