### PR TITLE
README: caption reflects magenta→cyan colormap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <p align="center">
   <img src="https://raw.githubusercontent.com/domattioli/ADMESH/main/docs/assets/hero/admesh_delbay_hero.gif" alt="ADMESH meshing Delaware Bay through three stages: initialized point cloud, DistMesh truss-solver relaxation, then FEM smoothing — element color tracks quality from magenta (poor) to cyan (equilateral)." width="100%">
   <br>
-  <em>A graded <a href="https://github.com/domattioli/ADMESH-Domains">Delaware Bay</a> mesh — fine in the upper river, coarse out in the open bay (<code>hmin</code>/<code>hmax</code> with gradient limit <code>g</code>) — evolving through ADMESH's pipeline: <strong>1.</strong> initialization → <strong>2.</strong> DistMesh truss solver → <strong>3.</strong> FEM smoothing. Element color tracks quality (red = poor → green = equilateral).</em>
+  <em>A graded <a href="https://github.com/domattioli/ADMESH-Domains">Delaware Bay</a> mesh — fine in the upper river, coarse out in the open bay (<code>hmin</code>/<code>hmax</code> with gradient limit <code>g</code>) — evolving through ADMESH's pipeline: <strong>1.</strong> initialization → <strong>2.</strong> DistMesh truss solver → <strong>3.</strong> FEM smoothing. Element color tracks quality (magenta = poor → cyan = equilateral).</em>
 </p>
 
 > **Attention MATLAB users:** This Python library is the actively-developed successor to the original MATLAB codebase by [Conroy et al.](https://github.com/coltonjconroy/ADMESH) (no longer maintained). An unmaintained copy of that original ADMESH MATLAB library is kept in-repo at [`src/matlab/`](src/matlab/) for provenance. Version 1.0.0 will ship with a MATLAB wrapper of the modernized code (Est. Aug 2026).


### PR DESCRIPTION
Fixes visible caption to match the actual Manim colormap and the alt-text: quality ranges from magenta (poor) to cyan (equilateral), not red to green.

https://claude.ai/code/session_017AtZPrzERpfote8F2mDnjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017AtZPrzERpfote8F2mDnjQ)_