### PR TITLE
chore: fix docs deploy gate + cleanup stale session branches

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,20 @@
+name: cleanup-stale-branches
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale claude/* session branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE "repos/domattioli/ADMESH/git/refs/heads/claude%2Fwonderful-tesla-1jawz" && echo "deleted wonderful-tesla-1jawz" || echo "wonderful-tesla-1jawz not found or already deleted"
+          gh api -X DELETE "repos/domattioli/ADMESH/git/refs/heads/claude%2Ftrusting-goldberg-2D0Ce" && echo "deleted trusting-goldberg-2D0Ce" || echo "trusting-goldberg-2D0Ce not found or already deleted"
+          gh api -X DELETE "repos/domattioli/ADMESH/git/refs/heads/claude%2Ftrusting-goldberg-2nc0X" && echo "deleted trusting-goldberg-2nc0X" || echo "trusting-goldberg-2nc0X not found or already deleted"
+          echo "Cleanup complete"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,21 +3,20 @@ name: docs
 on:
   push:
     branches:
-      - daily-issue-fixing
       - daily-maintenance
       - main
   workflow_dispatch:
 
 # Allow only one concurrent deployment, cancel runs already in progress.
 concurrency:
-  group: docs
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: write  # for mkdocs gh-deploy to push to gh-pages
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,6 +51,33 @@ jobs:
         # links; tracked separately).
         run: mkdocs build
 
-      - name: Deploy to gh-pages (daily-issue-fixing, daily-maintenance, or main)
-        if: github.ref == 'refs/heads/daily-issue-fixing' || github.ref == 'refs/heads/daily-maintenance' || github.ref == 'refs/heads/main'
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install C++ build deps
+        run: sudo apt-get install -y libeigen3-dev
+
+      - name: Install package + dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install pybind11
+          pip install -e ".[dev]"
+
+      - name: Generate interactive-demo frames
+        run: python scripts/gen_demo_frames.py
+
+      - name: Deploy to gh-pages
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
## What

Two changes:

### 1. Fix docs deployment proliferation

**Root cause:** `docs.yml` deployed to gh-pages on every push to `daily-maintenance`, `daily-issue-fixing`, AND `main` — creating a new GitHub Pages deployment record per commit on dev branches.

**Fix:** Split into two jobs:
- `build` — runs on `daily-maintenance` + `main` (CI validation, generates demo frames)
- `deploy` — runs only on `main`, depends on `build`

Removes `daily-issue-fixing` trigger (deprecated branch).

### 2. Cleanup stale session branches

Adds `.github/workflows/cleanup-branches.yml` (`workflow_dispatch` only) that deletes:
- `claude/wonderful-tesla-1jawz`
- `claude/trusting-goldberg-2D0Ce`
- `claude/trusting-goldberg-2nc0X`

## After merging

1. Merge this PR
2. Go to Actions → `cleanup-stale-branches` → Run workflow (from `main`)
3. Delete `cleanup-branches.yml` in a follow-up commit (or leave it — it only runs on `workflow_dispatch`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CLaTAdDDLKnNQ9JyzkMhrx)_