### PR TITLE
chore: DomI pin sync 04f5d53 + ADR-001 boundary verification log (#143 item 3, #146)

### DIFF
--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: 69fdeb77ec37aff5153093aa2b02805ab0a137f4
-manifest_sha256: a3447020bbc53de7086cf413c7f7f5efbc7879f27e1e6a888f554b529ea583c4
-pinned_at: 2026-06-09T03:37:06Z
+sha: 04f5d531d7e0f389167e4d73457650a485c522ca
+manifest_sha256: 6969753d1b278a949ae9ed389293a63c5c9368508cdd6f2ee2affc5b2f0516cb
+pinned_at: 2026-06-12T19:19:02Z

--- a/docs/adr/ADR-001-chilmesh-boundary.md
+++ b/docs/adr/ADR-001-chilmesh-boundary.md
@@ -90,3 +90,14 @@ Update this ADR's snapshot date and re-run the inventory if any of the following
 - ADMESH adds a new public `cons` module.
 - A new cross-repo test joins `tests/test_fort14_chilmesh_*.py`.
 - A maintainer disputes a `keep` row.
+
+## Verification log
+
+### 2026-06-12 — boundary re-verified under unification (ADMESH#143 item 3)
+
+Checked as part of the MADMESHing#48 / spec-048 unification effort:
+
+- **Invariants hold.** `import chilmesh` appears nowhere in `src/admesh/` except `viz.py` (lazy, behind the `[viz]` extra). `admesh.fort14` parses independently (stdlib + numpy only). `admesh.Mesh` remains canonical; no shared base class.
+- **Gates green** against sibling CHILmesh **1.2.0** HEAD: `test_unification_api_contract.py` (6), `test_fort14_chilmesh_compat.py` (8), `test_fort14_chilmesh_smoke.py` (1), `test_fort14_roundtrip.py` (6) — 21/21.
+- **Drift noted, not a violation:** `viz.py` now *delegates* plotting to chilmesh (`[viz]` extra = `chilmesh>=1.1`), inverting this ADR's original "moving forces CHILmesh install for plotting — net negative" rationale for the viz row. Disposition ("keep in ADMESH") unchanged; dependency is optional + lazy, so the no-hard-dep boundary stands.
+- **Reverification triggers have fired** (CHILmesh 1.0.0 major shipped 2026-05-22, the day after the snapshot; surface since grew `element_quality`, `submesh`, `paths_on_outer_vertices`, mutations, `quad_from_tri_pair`). Full inventory re-run is deliberately deferred: spec-048 **D5** (operator) decides whether this ADR is superseded (P6: single mesh type + single fort.14 parser in CHILmesh, tasks T20/T21) or kept. Re-running the inventory before D5 would be churn; if D5 = keep, re-run it then.

--- a/docs/introspections/rotation_2026-06-12T19Z.md
+++ b/docs/introspections/rotation_2026-06-12T19Z.md
@@ -1,0 +1,46 @@
+<!-- Session introspection + corpus entry. Caveman ultra. -->
+---
+date: 2026-06-12
+session: 2026-06-12T19Z-rotation
+repo: domattioli/ADMESH
+severity: low
+freq: recurring
+issues: [143, 146, 151]
+wasted_min: 6
+wasted_tok: 9000
+missing_skill: null
+---
+
+# ADMESH rotation 2026-06-12T19Z — maintenance slot (first A slot post-overhaul)
+
+## Summary
+
+Hour-19 rotation → ADMESH. Spec-048 A-tasks all operator-gated (T8/T9→D1, T12→D4, P6→D5) → maintenance track. Shipped: (1) DomI pin 69fdeb7→04f5d53 via sibling clone, #146 closed; (2) #143 item 3 — ADR-001 fort.14/CHILmesh boundary verified vs chilmesh 1.2.0, verification log appended to ADR; (3) gates green — boundary 21/21, full suite 409 pass / 9 skip / 1 xfail (by-design). PR #151 (draft → main). #140 verified fully shipped, parked operator sign-off. Claim + checklist on MADMESHing#48. No DomI bugs hit. No code edits → no Haiku dispatch needed (docs/verification only).
+
+## What worked (top 3, evidence)
+
+1. Sibling-clone pin path (#230/#223): `update_pin.sh` refreshed pin w/o network plugin install. Zero friction.
+2. Map-first discipline: #48 read before write → A-slice unambiguous (digest's "rolls to rotation" line + #143 items); no invented scope.
+3. Installing sibling CHILmesh editable (1.2.0) into venv → ADR boundary check ran against live HEAD, not stale PyPI — caught viz-row rationale drift.
+
+## What didn't (top 3, evidence)
+
+1. Caveman plugin late-connect at bootstrap → `Unknown skill` → #168 fallback line; real Skill call succeeded only mid-session after marketplace connect. Known #268 (fix inert until DomI PR #274 merges) — 2nd confirmed instance post-fix-on-development.
+2. #48 comment thread fetch = 56KB → MCP result overflow → manual python/jq slicing. Large-thread reads need pagination habit from start.
+3. ADMESH has no `development` branch; harness mandates `claude/epic-sagan-hkmynu` while DomI branching.md says development → shipped on harness branch → PR → main. Policy ambiguity persists in A repo only (C/Q/M migrated).
+
+## Pain → matrix rows
+
+| Pain | Severity | Freq | Tracking | Saved-min/session |
+|---|---|---|---|---|
+| caveman warm-load inert until DomI#274 merges (#268 AC1) | low | recurring (2nd) | DomI#268 | 2 |
+| MCP large-thread fetch overflow → manual slicing | low | recurring class | — (habit: paginate) | 4 |
+| ADMESH branch policy vs harness branch (no `development`) | medium | recurring | branching.md migration gap | 5 |
+
+No new `request: skill` — #203 probation respected.
+
+## Next steps
+
+- [ ] Operator: merge PR #151 (pin + ADR log); sign off #140.
+- [ ] D1/D4/D5 remain the A-side gates; next A slot stays maintenance unless decided.
+- [ ] If D5 = keep → re-run ADR-001 inventory (triggers fired, deferred deliberately).


### PR DESCRIPTION
## What

Rotation 2026-06-12 hour-19 ADMESH slot (maintenance track; spec-048 A-tasks all operator-gated D1/D4/D5).

1. **`.domi-pin`** — re-synced 69fdeb7 → **04f5d53** via sibling DomI clone (closes #146; supersedes the interim c2b52d4 bump noted on that issue).
2. **`docs/adr/ADR-001-chilmesh-boundary.md`** — verification-log section added for ADMESH#143 item 3: boundary re-verified under unification against sibling CHILmesh **1.2.0**.

## Verification

- Boundary gates: contract test (6) + fort14 chilmesh compat (8) + smoke (1) + fort14 round-trip (6) = **21/21 green** with chilmesh 1.2.0 installed.
- Full suite: **409 passed, 9 skipped, 10 deselected, 1 xfailed** (xfail is the documented #65/#140 by-design deferral).
- Invariants confirmed: no `chilmesh` import outside lazy `viz.py` `[viz]` extra; `admesh.fort14` parser independent; `admesh.Mesh` canonical.
- Drift recorded (not a violation): `viz.py` now delegates plotting to chilmesh — ADR rationale stale, disposition unchanged. ADR's own reverification triggers have fired (CHILmesh 1.0.0 major post-snapshot); full inventory re-run deliberately deferred to the spec-048 **D5** decision.

## Refs

- ADMESH#143 (coordination thread — item 3 was the last open item)
- domattioli/MADMESHing#48 (map of record; claim + checklist comments)
- Closes #146

https://claude.ai/code/session_014Xe42xGQzvNQxJeygPMnto

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xe42xGQzvNQxJeygPMnto)_