### PR TITLE
docs: complete public-surface docstrings + enforce Parameters/Returns gate

### DIFF
--- a/src/admesh/fort14.py
+++ b/src/admesh/fort14.py
@@ -329,6 +329,28 @@ def write_fort14(
 
     Applies 0-based → 1-based index conversion and elevation → depth sign
     flip. Coordinates are emitted with ``precision`` decimal places.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Triangulation to serialize. Node coordinates, element connectivity,
+        optional bathymetry, and boundary segments are all written.
+    path : str | os.PathLike[str] | TextIO
+        Destination file path, or an already-open text stream (written to in
+        place and left open by the caller).
+    precision : int, optional
+        Number of decimal places for emitted coordinates (default ``6``).
+        Must be ``>= 1``.
+
+    Returns
+    -------
+    None
+        The mesh is written to ``path`` for its side effect.
+
+    Raises
+    ------
+    ValueError
+        If ``precision < 1``.
     """
     if precision < 1:
         raise ValueError(f"precision must be ≥ 1, got {precision}")

--- a/src/admesh/gmsh.py
+++ b/src/admesh/gmsh.py
@@ -144,6 +144,22 @@ def read_msh(path: "str | os.PathLike[str] | TextIO") -> Mesh:
     Triangles become ``Mesh.elements`` (0-based); dim-1 physical groups
     become ordered :class:`BoundarySegment` records; node ``z`` becomes
     ``bathymetry`` when any value is non-zero.
+
+    Parameters
+    ----------
+    path : str | os.PathLike[str] | TextIO
+        Source ``.msh`` file path, or an already-open text stream.
+
+    Returns
+    -------
+    Mesh
+        Mesh with 0-based triangle connectivity, ordered boundary segments
+        recovered from dim-1 physical groups, and bathymetry from node ``z``.
+
+    Raises
+    ------
+    GmshParseError
+        If the file is not ASCII Gmsh format 2.x or is otherwise malformed.
     """
     lines, handle = _open_text(path)
     cursor = _Cursor(lines)
@@ -306,6 +322,28 @@ def write_msh(
     Emits a dim-2 ``domain`` physical group for the triangles and one
     dim-1 group per boundary segment (``<label>_<index>``). Node ``z``
     carries bathymetry/elevation (``0`` when unset).
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Triangulation to serialize. Triangles, boundary segments, and optional
+        bathymetry are written.
+    path : str | os.PathLike[str] | TextIO
+        Destination file path, or an already-open text stream (written to in
+        place and left open by the caller).
+    precision : int, optional
+        Number of decimal places for emitted coordinates (default ``6``).
+        Must be ``>= 1``.
+
+    Returns
+    -------
+    None
+        The mesh is written to ``path`` for its side effect.
+
+    Raises
+    ------
+    ValueError
+        If ``precision < 1``.
     """
     if precision < 1:
         raise ValueError(f"precision must be ≥ 1, got {precision}")

--- a/src/admesh/valence.py
+++ b/src/admesh/valence.py
@@ -205,7 +205,22 @@ def balance_valence_triangles(
 
 
 def get_valence_report(mesh: "Mesh", config: BalanceConfig | None = None) -> str:
-    """Return a human-readable valence statistics report for *mesh*."""
+    """Return a human-readable valence statistics report for *mesh*.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Mesh whose interior-node vertex valences are summarized.
+    config : BalanceConfig | None, optional
+        Valence-balancing configuration; supplies the ``ideal_valence``
+        target. Defaults to ``BalanceConfig()`` when ``None``.
+
+    Returns
+    -------
+    str
+        Multi-line report: interior-node count, min/mean/max valence, and the
+        percentage of interior nodes at the ideal valence.
+    """
     cfg = config or BalanceConfig()
     bnd = _boundary_mask(mesh)
     val = compute_valence(mesh.elements)

--- a/tests/test_docstring_completeness.py
+++ b/tests/test_docstring_completeness.py
@@ -6,8 +6,10 @@ either `Parameters`/`Returns` (functions) or attribute documentation
 (classes / dataclasses). At least one runnable `Examples` block is
 recommended but not strictly required for very small wrappers.
 
-Per spec 009 R3 (FR-025). Treated as a soft warning (skip) for the
-0.1.0 tag and tightened to a hard gate at 0.2.0.
+Per spec 009 R3 (FR-025). The Parameters/Returns gate was a soft
+warning (skip) through the 0.1.0 tag; the public-surface backlog
+reached zero past the planned 0.2.0 tightening, so the gate is now a
+hard assertion (current version 0.5.x).
 """
 
 from __future__ import annotations
@@ -93,11 +95,11 @@ def test_callable_docstrings_have_parameters_or_returns(
             for section in ("Parameters", "Returns", "Yields", "Raises")
         ):
             weak.append(name)
-    # Soft-warn for 0.1.0; not yet a hard fail since some legacy docstrings
-    # are short summaries only. Tighten to assert (no `if weak: pytest.skip`)
-    # at 0.2.0.
-    if weak:
-        pytest.skip(
-            f"{len(weak)} public callables lack Parameters/Returns sections: {weak}. "
-            f"Tighten to a hard fail at 0.2.0."
-        )
+    # Hard gate: every public callable taking arguments must reference a
+    # NumPy sectional header. The backlog reached zero past the 0.2.0 tag,
+    # so the former soft-skip is now an assertion — this guards against a
+    # silent regression when a new public callable is added without sections.
+    assert not weak, (
+        f"{len(weak)} public callables lack Parameters/Returns sections: {weak}. "
+        f"Add NumPy-style Parameters/Returns/Yields/Raises per spec 009 FR-025."
+    )


### PR DESCRIPTION
## What

ADMESH rotation (hour-17, 2026-06-16, **maintenance track** per MADMESHing#48 — ADMESH overhaul slice complete in prior slots, #143 thread).

Surfaced by running the test suite: `tests/test_docstring_completeness.py` was **skipping** with `4 public callables lack Parameters/Returns sections: ['write_fort14', 'read_msh', 'write_msh', 'get_valence_report']. Tighten to a hard fail at 0.2.0.` The repo is now at **v0.5.1** — three minor versions past that planned tightening — so the soft-skip was stale debt and exactly the silent-false-green class that bit sibling repos (QuADMesh #93, MADMESHing/CHILmesh fixture-skip gates).

Two-part fix:

1. **Added NumPy-style `Parameters`/`Returns` (+ `Raises`) sections** to the 4 public callables that lacked them:
   - `write_fort14` (`src/admesh/fort14.py`)
   - `read_msh`, `write_msh` (`src/admesh/gmsh.py`)
   - `get_valence_report` (`src/admesh/valence.py`)
2. **Tightened the gate** from `if weak: pytest.skip(...)` to `assert not weak` so any future public callable added to `__all__` without sections fails CI instead of silently skipping. Updated the module docstring + inline rationale accordingly.

## Why it's safe

- Docs/test only — **no logic, signatures, or behavior changed** (verified `git diff`: docstring blocks + the test's skip→assert swap).
- Backlog is now **zero** (`weak callables: []`), so the hard assert passes today.
- Full suite: **440 passed, 13 skipped, 1 xfailed** (was 439 passed + 1 skip; the docstring test now passes instead of skipping).

## Constitution note

The 4 touched modules: `fort14.py`, `gmsh.py`, `valence.py` are all **additive-layer** (I/O + reporting), not the 13 locked faithful-port stage modules. Principle I untouched.

Refs domattioli/MADMESHing#48

---
_ADMESH rotation 2026-06-16T17Z_

https://claude.ai/code/session_01VmJyjE6GxZeL4anJW9DeLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmJyjE6GxZeL4anJW9DeLN)_