### PR TITLE
test: silence class-scoped fixture instance-method deprecation (pytest 10 forward-compat)

### DIFF
--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: a9b240f2d6f2158e2273da46a800af3ff70c6132
-manifest_sha256: 8e928b85a6aa6b7e3869cb3d04832eb2b2576a9a343e5cf4a92ad7890782cb75
-pinned_at: 2026-06-16T01:05:48Z
+sha: e369b5c6698095db4c66a753ea16d892c1dfbdbb
+manifest_sha256: b5dd8ad84e534e9958bfa05baf4000769e1f54e9d3be8e247551cfc3676d5dda
+pinned_at: 2026-06-18T09:05:32Z

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -76,7 +76,8 @@ class TestNotchedRectangleBoundaryCoverage:
     """Verify that 1D seeding guarantees adequate notch-wall node coverage."""
 
     @pytest.fixture(scope="class")
-    def mesh(self):
+    @staticmethod
+    def mesh():
         p, t = triangulate(NOTCHED_RECTANGLE, h0=0.05, seed=0, niter=300)
         return p, t
 


### PR DESCRIPTION
## What

ADMESH rotation (hour-09, 2026-06-18, **maintenance track** — MADMESHing#48 closed/completed by operator 2026-06-18, overhaul phase done).

Surfaced by running the full suite (`439 passed, 14 skipped, 1 xfailed`): the only warning is a forward-compat break —

```
tests/test_routine.py::TestNotchedRectangleBoundaryCoverage::test_right_notch_wall_coverage
  PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated.
```

The class-scoped `mesh` fixture took `self`, which pytest 10 will reject. Fix = make it a `@staticmethod`: keeps the class-scoped sharing of the expensive `triangulate(NOTCHED_RECTANGLE, niter=300)` call across the 4 tests, removes the instance binding.

```diff
     @pytest.fixture(scope="class")
-    def mesh(self):
+    @staticmethod
+    def mesh():
         p, t = triangulate(NOTCHED_RECTANGLE, h0=0.05, seed=0, niter=300)
         return p, t
```

## Verification

- `pytest tests/test_routine.py` → **19 passed, no warnings** (was 19 passed + 1 PytestRemovedIn10Warning).
- Full suite unchanged otherwise: 439 passed.

## Scope / safety

- **Test-only.** No stage module touched → Constitution Principle I untouched.
- Single-purpose. Deliberately does **not** duplicate the already-open maintenance draft PRs (#167 docstring gate, #168 README markdown/typo, #169 CITATION.cff) — see the note I'm leaving on #143.
- Bundled the routine `chore: sync DomI pin a9b240f → e369b5c` (offline sibling-clone sync that cleared the session-start drift hard-stop) as a separate commit.

Refs domattioli/MADMESHing#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvrSq7nw8eWx9z67yPDhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01StvrSq7nw8eWx9z67yPDhc)_