### PR TITLE
docs: fix README Status & Roadmap formatting + sync DomI pin

### DIFF
--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: a9b240f2d6f2158e2273da46a800af3ff70c6132
-manifest_sha256: 8e928b85a6aa6b7e3869cb3d04832eb2b2576a9a343e5cf4a92ad7890782cb75
-pinned_at: 2026-06-16T01:05:48Z
+sha: e369b5c6698095db4c66a753ea16d892c1dfbdbb
+manifest_sha256: b5dd8ad84e534e9958bfa05baf4000769e1f54e9d3be8e247551cfc3676d5dda
+pinned_at: 2026-06-18T17:05:16Z

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@
 
 ## Status & Roadmap
 
-**Current status (June 2026): Stable and actively-maintained.
-** Octree adaptive background grid (`background="octree"`) to improve medial axis and channel feature widths.
+**Current status (June 2026): stable and actively maintained.** Most recent feature: an octree adaptive background grid (`background="octree"`) that improves medial-axis and channel-feature width resolution.
 
 - **Now:** address open issues.
 - **Next:** enhanced pre- and post-processing for quality improvement; performance optimization; evaluate a C++ or Rust backend; parallelization.

--- a/docs/introspections/2026-06-18T17Z-admesh-rotation.md
+++ b/docs/introspections/2026-06-18T17Z-admesh-rotation.md
@@ -1,0 +1,40 @@
+---
+session: 2026-06-18T17Z-admesh-rotation
+repo: ADMESH
+model: claude-opus-4-8[1m]
+mode: maintenance
+branch: claude/epic-curie-jv9zq4 (harness-injected; PR → main per Constitution VI.1)
+rotation_slot: hour-17 (ADMESH per wall-time roster)
+tokens_wasted: ~0 — drift hard-stop was real this slot (pin genuinely behind), cleared in 2 calls
+---
+
+# ADMESH rotation — 2026-06-18T17Z
+
+## What changed
+- **PR #171** (draft → `main`): `docs:` fix README "Status & Roadmap" broken-bold + dangling
+  "Octree adaptive background grid" fragment (closing `**` had wrapped to the next line);
+  `chore:` refresh `.domi-pin` `a9b240f → e369b5c` via `update_pin.sh` (local DomI mirror).
+- **Filed #172** — branch-policy conflict + `development`↔`main` divergence (operator-needed).
+
+## Findings
+- **Caveman:** NOT loaded (plugin absent from skill menu) → emulated from CLAUDE.md ultra rules.
+- **MADMESHing#48 is CLOSED (completed 2026-06-18T01:05Z).** Overhaul map done → maintenance track.
+  Did NOT post a #48 claim/checklist comment (slice complete; comment frugality).
+- **DomI drift hard-stop was REAL this slot** (unlike the hour-09 false alarm): main's pin `a9b240f`
+  was genuinely behind upstream `e369b5c`. `update_pin.sh` resolved it from the `/home/user/DomI`
+  sibling mirror (marketplace install fails — no network egress; expected).
+- **Branch governance is a mess (now tracked in #172).** Constitution Article VI.1 = trunk-based
+  on `main`; DomI universal `branching.md` = `development` staging. Sessions split between the two.
+  `development` is 142 ahead / 6 behind `main`, has a restructured README + stale pin (`69b073d`).
+  6 `claude/epic-curie-*` sprawl branches on origin. Targeted PR #171 at `main` because (a) the
+  broken README render is live on production `main`, (b) Constitution VI.1 says trunk-based main,
+  (c) `development`'s README is already restructured so a main-based fix wouldn't apply cleanly.
+  Reconciliation is operator-only (142/6 divergence = high regression risk) → #172.
+
+## Pains → matrix (no new request:skill per #203)
+- **Pin/branch coupling pain:** the startup drift check runs against whatever harness branch you
+  land on; on a repo where the canonical branch is contested, "is the pin actually behind?" needs
+  cross-branch inspection before trusting the hard-stop. Cost this slot: low (pin was behind on all
+  branches). Mitigation already in CHILmesh/QuADMESH lessons: switch to canonical branch first.
+- **Branch sprawl from harness `claude/epic-curie-<hash>` injection:** recurring across repos; ADMESH
+  now has 6. Same root cause documented in CHILmesh "Branch Sprawl Incidents". Tracked in #172.


### PR DESCRIPTION
## Summary

Maintenance-track rotation session (ADMESH slot, hour 17 UTC; MADMESHing#48 overhaul map now closed → maintenance).

- **`docs:`** Fix a broken markdown render in README "Status & Roadmap": the current-status line's closing `**` had wrapped to the next line, breaking the bold and leaving `Octree adaptive background grid…` as an orphaned fragment. Folded into one well-formed sentence.
- **`chore:`** Refresh `.domi-pin` `a9b240f → e369b5c` (cleared the session-start DomI drift HARD STOP) via `update_pin.sh` against the local DomI mirror.

## Test

Docs + pin ledger only — no code paths touched. Faithful-port stage modules (Constitution Principle I) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bhwrxaq4WEVYBNsZMuKVh

---
_Generated by [Claude Code](https://claude.ai/code/session_017bhwrxaq4WEVYBNsZMuKVh)_