### PR TITLE
chore: sync DomI pin a9b240f → e369b5c

### DIFF
--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: a9b240f2d6f2158e2273da46a800af3ff70c6132
-manifest_sha256: 8e928b85a6aa6b7e3869cb3d04832eb2b2576a9a343e5cf4a92ad7890782cb75
-pinned_at: 2026-06-16T01:05:48Z
+sha: e369b5c6698095db4c66a753ea16d892c1dfbdbb
+manifest_sha256: b5dd8ad84e534e9958bfa05baf4000769e1f54e9d3be8e247551cfc3676d5dda
+pinned_at: 2026-06-19T09:05:42Z


### PR DESCRIPTION
## Summary

ADMESH rotation session (hour-09 UTC, **maintenance track** — MADMESHing#48 overhaul map closed/completed by operator 2026-06-18).

- **`chore:`** Refresh `.domi-pin` `a9b240f → e369b5c` (offline sibling-clone sync vs `/home/user/DomI` via `update_pin.sh`) — cleared the session-start DomI drift HARD STOP. Pin-ledger only.

## Scope / safety

- `.domi-pin` only (+3/−3). No code, API, or behavior change.
- Constitution Principle I untouched (no faithful-port stage-module edits).

## Note for the reconcile pass

This is the **same pin refresh already bundled in open drafts #166–#171** — see the consolidated table I posted on #172. When merging, keep the first pin commit and **drop the redundant ones** from the other drafts. Filed here as a single-purpose chore per the per-session push flow; the branch-sprawl root cause + suggested prune pass are documented on #172 (needs-operator).

Refs domattioli/ADMESH#172, domattioli/MADMESHing#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW1vstbeT17wWEDSjunh3q)_