### PR TITLE
docs: document sibling-clone fallback for DomI plugin marketplace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This repo = downstream consumer of [`domattioli/DomI`](https://github.com/domatt
 **Plumbing:**
 - `.domi-pin` (committed) — ledger of upstream SHA + MANIFEST.md sha256.
 - `scripts/instructions_on_start.sh` — startup hook with drift gate.
-- `sync-from-domi`, `request-from-domi`, `introspect` plugins — installed from DomI marketplace (`claude plugin marketplace add domattioli/DomI`).
+- `sync-from-domi`, `request-from-domi`, `introspect` plugins — installed from DomI marketplace (`claude plugin marketplace add domattioli/DomI`). In practice the marketplace `add` step fails from this network in most sessions (see corpus entries `development_2feb33a`, `development_848293d`, `rotation_2026-06-12T19Z`, `cpp-distmesh_d69677b`, `daily-issue-fixing_ca1fcb4`); the documented fallback is a sibling clone of `domattioli/DomI` (or the DomI plugin-cache directory if already present from a prior session) read directly, without going through the marketplace network path.
 
 **MUST NOT** edit DomI-owned skills directly in this repo. Submit changes upstream via `request-from-domi`; downstream = pull-only.
 


### PR DESCRIPTION
## Summary
- Part of the 2026-07 `introspect` monthly review (#179).
- One-line addition to `CLAUDE.md`'s DomI Sync Contract section: documents the sibling-clone/plugin-cache fallback for when `claude plugin marketplace add domattioli/DomI` fails from this network — which corpus evidence shows is the majority case, not the exception.
- Does not touch the live, unresolved branch-policy conflict already tracked in #172 (Constitution/CLAUDE.md say main-only + speckit-only branches; `development` is in active practice) — that's a policy call for the operator, out of scope here.

## Test plan
- [x] Docs-only change, no code/behavior affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLxXNUYYNmWTErAioxdhL)_