### PR TITLE
docs: correct ADMESH lineage to parallel-branches wording

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,6 +36,35 @@ keywords:
   - finite-element
   - coastal-modeling
   - python
+references:
+  - type: article
+    title: "An automatic mesh generator for coupled 1D-2D hydrodynamic models"
+    authors:
+      - family-names: Kang
+        given-names: Younghun
+      - family-names: Kubatko
+        given-names: Ethan J.
+    journal: "Geoscientific Model Development"
+    year: 2024
+    volume: 17
+    start: 1603
+    end: 1625
+    doi: 10.5194/gmd-17-1603-2024
+    notes: "Describes ADMESH+ v3, the original group's current MATLAB line; this repository is a parallel Python port of the 2012 library."
+  - type: software
+    title: "Younghun-Kang/ADMESH: v3.0.1"
+    authors:
+      - family-names: Kang
+        given-names: Younghun
+      - family-names: Kubatko
+        given-names: Ethan J.
+      - family-names: Conroy
+        given-names: Colton J.
+      - family-names: West
+        given-names: Dustin W.
+    year: 2023
+    doi: 10.5281/zenodo.10242565
+    repository-code: "https://github.com/OSU-CHIL/ADMESH"
 preferred-citation:
   type: article
   title: "ADMESH: an advanced, automatic unstructured mesh generator for shallow water models"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# CONTEXT.md — ADMESH (Python port) glossary
+
+Canonical language for this repo. Glossary only — no implementation details.
+
+## Lineage terms
+
+- **ADMESH (2012 original)** — the MATLAB mesh generator described in Conroy, Kubatko & West (2012), *Ocean Dynamics* 62. Source of this repo's port lineage, vendored at `src/matlab/` via `domattioli/QuADMesh-MATLAB`.
+- **Conroy repo** — `github.com/coltonjconroy/ADMESH`, the original public MATLAB codebase of ADMESH (2012 original). Itself no longer updated; its lineage continues upstream as ADMESH+ v3.
+- **ADMESH+ v3** — the most recent MATLAB ADMESH from the original research group: Kang, Kubatko, Conroy & West, v3.0.1, Zenodo `10.5281/zenodo.10242565` (GitHub `OSU-CHIL/ADMESH`). Adds 1D–2D coupled-model constraint extraction and GUI components. Described in Kang & Kubatko (2024), *Geosci. Model Dev.* 17, `10.5194/gmd-17-1603-2024`.
+- **The port (this repo)** — `admesh2D`, an independent Python port of ADMESH (2012 original). NOT derived from ADMESH+ v3; the two are parallel branches of the same 2012 root. Both branches are acknowledged in the README.
+
+## Naming rules
+
+- Never describe this repo as "the successor" to MATLAB ADMESH — ADMESH+ v3 is the original group's active line. This repo is "a Python port of the 2012 original".
+- "ADMESH+" refers exclusively to the Kang/Kubatko MATLAB line, never to this package. (QuADMESH+ is a different, unrelated "+": the quad-meshing thesis algorithm.)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 
-> **MATLAB users:** This library is the actively-developed successor to the original MATLAB codebase by [Conroy et al.](https://github.com/coltonjconroy/ADMESH) (no longer maintained). An unmaintained copy of that original is kept in-repo at [`src/matlab/`](src/matlab/) for provenance.
+> **Lineage:** Two branches of ADMESH descend from the 2012 original by [Conroy et al.](https://github.com/coltonjconroy/ADMESH) The original group's current MATLAB line is **ADMESH+ v3** ([OSU-CHIL/ADMESH](https://github.com/OSU-CHIL/ADMESH); archived at [10.5281/zenodo.10242565](https://doi.org/10.5281/zenodo.10242565)), maintained by Younghun Kang with Ethan Kubatko: it adds constraint extraction for coupled 1D–2D hydrodynamic models, a revised medial-axis method, and GUI components ([Kang & Kubatko, 2024](https://doi.org/10.5194/gmd-17-1603-2024)). This repository is the parallel branch: an independent Python port of the 2012 library, maintained separately. A copy of the ported MATLAB source is vendored at [`src/matlab/`](src/matlab/) for provenance.
 
 ---
 
@@ -139,6 +139,12 @@ python benchmarks/compare_versions.py --hist \
 
 > Mattioli, D.O., Conroy, C.J., West, D.W., Kubatko, E.J. (2026). ADMESH: An advanced, automatic unstructured mesh generator for 2D shallow-water models (Python port). Zenodo. <https://doi.org/10.5281/zenodo.20264101>
 
+**Upstream MATLAB line** (ADMESH+, if you use or compare against it):
+
+> Kang, Y. & Kubatko, E.J. (2024). An automatic mesh generator for coupled 1D–2D hydrodynamic models. *Geoscientific Model Development* 17, 1603–1625. <https://doi.org/10.5194/gmd-17-1603-2024>
+>
+> Kang, Y., Kubatko, E.J., Conroy, C.J. & West, D.W. (2023). Younghun-Kang/ADMESH: v3.0.1. Zenodo. <https://doi.org/10.5281/zenodo.10242565>
+
 A [`CITATION.cff`](CITATION.cff) feeds GitHub's "Cite this repository" button; version-specific DOIs are on the [Zenodo record](https://doi.org/10.5281/zenodo.20264101).
 
 ## Documentation
@@ -150,6 +156,7 @@ API reference lives in the docstrings (`triangulate`, `Domain`, `Mesh`, `Boundar
 Issues and pull requests are welcome on [GitHub](https://github.com/domattioli/ADMESH).
 
 - **Theory** (algorithm, size-field formulation, ADCIRC integration): [Colton Conroy](https://github.com/coltonjconroy) | [Ethan Kubatko](https://ceg.osu.edu/people/kubatko.3)
+- **Upstream MATLAB line** (ADMESH+ v3: 1D–2D constraints, medial axis, GUI): [Younghun Kang](https://github.com/Younghun-Kang) | [Ethan Kubatko](https://ceg.osu.edu/people/kubatko.3)
 - **This repository** (python port, active maintenance): [Dominik Mattioli](https://github.com/domattioli)
 
 ## License


### PR DESCRIPTION
## What

The README claimed the original MATLAB codebase is no longer maintained. That claim is wrong: the original group's line continues as ADMESH+ v3.0.1 (Kang, Kubatko, Conroy & West; [zenodo 10.5281/zenodo.10242565](https://doi.org/10.5281/zenodo.10242565); [OSU-CHIL/ADMESH](https://github.com/OSU-CHIL/ADMESH)), which adds constraint extraction for coupled 1D–2D hydrodynamic models, a revised medial-axis method, and GUI components ([Kang & Kubatko, 2024](https://doi.org/10.5194/gmd-17-1603-2024)).

## Changes

- README lineage note now presents the two branches as parallel: ADMESH+ v3 upstream in MATLAB; this repository as an independent Python port of the 2012 library. Both branches credited.
- Citation section gains an "Upstream MATLAB line" entry (Kang & Kubatko 2024 paper + v3.0.1 Zenodo record); Contributing section credits Younghun Kang.
- CITATION.cff gains the two upstream references.
- CONTEXT.md (new) records the canonical lineage vocabulary, including the rule that "ADMESH+" refers only to the Kang/Kubatko MATLAB line.

Docs only; no code paths touched.

[model: claude-fable-5, repo: domattioli/ADMESH, session: session_01ENr1e1WUtKhYvwG8fVFrCo]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENr1e1WUtKhYvwG8fVFrCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENr1e1WUtKhYvwG8fVFrCo)_