### PR TITLE
fix: remove duplicate top-level permissions block in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 concurrency:
   group: publish
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- `main`'s `publish.yml` has a duplicate top-level `permissions:` block — a squash-merge artifact from #190 and #191 landing near-identical hunks that both applied additively.
- Invalid YAML — GitHub rejects the workflow (`'permissions' is already defined`), blocking every run including manual `workflow_dispatch`.
- Branched directly off `main` (not `development`, which has diverged via repeated squash-merges) so this diff touches exactly one file, one 3-line removal — supersedes #192, which picked up 405 lines of unrelated noise.

## Test plan
- [x] `git diff origin/main` shows only the 3-line removal, nothing else
- [x] YAML validated
- [ ] Manual dispatch on `main` after merge confirms the workflow runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENr1e1WUtKhYvwG8fVFrCo)_