### PR TITLE
fix: drop -march=native from distributed wheel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,14 @@ if HAS_PYBIND11 and eigen_path is not None:
             ],
             include_dirs=include_dirs,
             language='c++',
-            extra_compile_args=['-O3', '-march=native'] if sys.platform != 'win32' else ['/O2'],
+            # No -march=native: this builds distributed PyPI wheels, not a
+            # local binary. -march=native ties the wheel's instruction set
+            # to the exact build-machine CPU (crashes with "illegal
+            # instruction" on end users' older/different CPUs), and breaks
+            # outright when cross-compiling (cibuildwheel's macOS x86_64
+            # leg on an Apple Silicon arm64 runner resolves "native" to
+            # the host's arm64 CPU while targeting -arch x86_64).
+            extra_compile_args=['-O3'] if sys.platform != 'win32' else ['/O2'],
         ),
     ]
 


### PR DESCRIPTION
## Summary
- The manual `workflow_dispatch` publish run (after #193's fix landed) still failed — `Build wheels on macos-latest` broke with `error: unknown target CPU 'apple-m3'`. GitHub's `macos-latest` runner is now Apple Silicon (arm64 host); cibuildwheel's `x86_64` macOS leg cross-compiles to `-arch x86_64`, but `-march=native` resolves to the host's native arm64 CPU — an invalid combination under `-arch x86_64`.
- Independent of the CI break, `-march=native` was already unsound for a **distributed** PyPI wheel: it ties the compiled instruction set to the exact build machine's CPU, which can crash with "illegal instruction" on an end user's older/different CPU. `-O3` alone is the correct, portable choice.
- Minimal fix: drop `-march=native` from `setup.py`'s `extra_compile_args`, keep `-O3`.

## Test plan
- [x] `python -m ast` syntax check passes
- [x] Change is strictly flag-removal — anything that compiled with `-O3 -march=native` compiles with `-O3` alone
- [ ] Next `workflow_dispatch` run confirms macOS wheel build (both x86_64 and arm64 legs) succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENr1e1WUtKhYvwG8fVFrCo)_