### PR TITLE
fix: force binary numba/llvmlite in cibuildwheel test venv

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,12 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: "brew install eigen"
           CIBW_ENVIRONMENT: "ADMESH_REQUIRE_CPP=1"
           CIBW_BEFORE_BUILD: "pip install pybind11"
-          # Ensure scipy/numpy are prebuilt wheels in test venv (avoid from-source build on manylinux missing OpenBLAS)
-          CIBW_BEFORE_TEST: "pip install --only-binary=:all: numpy scipy"
+          # Force prebuilt wheels for numpy/scipy/numba in the test venv. Without
+          # this, pip falls back to building from source: scipy fails on manylinux
+          # (missing OpenBLAS), and numba's llvmlite dependency fails on macOS
+          # x86_64-under-Rosetta cross-arch test venvs (llvmlite/setuptools
+          # incompatibility: LlvmliteClean missing user_options).
+          CIBW_BEFORE_TEST: "pip install --only-binary=:all: numpy scipy numba"
           CIBW_TEST_COMMAND: "python -c \"import admesh\""
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- After #195's `-march=native` fix, the macOS wheel build itself succeeded — but the post-build `CIBW_TEST_COMMAND` install step still failed: `numba` (a hard dependency) pulled in `llvmlite`, which has no prebuilt wheel for the `cp310-macosx x86_64`-under-Rosetta cross-arch test venv on the arm64 runner. pip fell back to a source build that hit a real llvmlite/setuptools incompatibility (`LlvmliteClean` missing `user_options`).
- Extends the existing `--only-binary=:all:` pin (already covering numpy/scipy for the manylinux OpenBLAS issue from #190) to also include `numba`, so its own compatible prebuilt wheel resolves instead of triggering a source build of llvmlite.

## Test plan
- [x] YAML validated
- [ ] Next `workflow_dispatch` run confirms macOS wheel build + test-install succeeds end to end


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENr1e1WUtKhYvwG8fVFrCo)_