### PR TITLE
ci: viz-interop lane so chilmesh/matplotlib tests actually run (#197)

### DIFF
--- a/.domi-pin
+++ b/.domi-pin
@@ -4,6 +4,6 @@
 
 upstream: domattioli/DomI
 branch: main
-sha: 8e259ae3b26edfd1324a35ae44a165bb75baf749
-manifest_sha256: 763609cfbceef1e8545a572418e9ea673ecd576618c736728b7ac7bdd3d415da
-pinned_at: 2026-07-04T00:00:00Z
+sha: cfa7f02a4661ed0db8cce9eee7cf3c93b4f0e863
+manifest_sha256: 124153ce0aa71c06ee4836c51488d067032327312c36be5451ad6b0e02af7341
+pinned_at: 2026-07-10T01:00:00Z

--- a/.github/workflows/LOCAL.md
+++ b/.github/workflows/LOCAL.md
@@ -11,3 +11,4 @@ workflows fail the workflow-conformance gate.
 | `docs.yml` | mkdocs site deploy to admesh.domattioli.com — repo-specific |
 | `publish.yml` | PyPI release, tag-triggered — repo-specific release pipeline |
 | `tests-slow.yml` | slow-lane pytest (block_o fixtures) — migration candidate for the tests.yml template later |
+| `viz-interop.yml` | chilmesh + matplotlib interop tests (#197) — the DomI-managed `tests.yml` installs only `.[dev]` and cannot install the `viz` extra, so these 4 tests would always skip; paths-filtered to the viz surface to minimize CI minutes |

--- a/.github/workflows/viz-interop.yml
+++ b/.github/workflows/viz-interop.yml
@@ -1,0 +1,51 @@
+# Repo-local workflow (spec-010 v3) — registered in .github/workflows/LOCAL.md.
+# Runs the chilmesh/matplotlib interop tests that the standard tests.yml lane
+# always skips (it installs only .[dev], which lacks the viz extra). See #197.
+# Paths-filtered to the viz surface so it only spends CI minutes when the
+# code these tests exercise actually changes.
+name: viz-interop
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/admesh/viz.py'
+      - 'src/admesh/api.py'
+      - 'src/admesh/fort14.py'
+      - 'tests/test_viz.py'
+      - 'tests/test_fort14_chilmesh_smoke.py'
+      - 'pyproject.toml'
+      - '.github/workflows/viz-interop.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: viz-interop-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  viz-interop:
+    name: viz interop (chilmesh + matplotlib)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package + dev,viz extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,viz]"
+
+      - name: Run viz + chilmesh-interop tests
+        run: |
+          python -m pytest tests/test_viz.py tests/test_fort14_chilmesh_smoke.py -q --tb=short


### PR DESCRIPTION
## Summary

Closes #197. The DomI-managed `tests.yml` installs only `.[dev]`, so the four chilmesh/matplotlib interop tests always **skip** in the PR gate — they protected nothing. Since `tests.yml` is a managed template (`DO NOT EDIT IN THIS REPO`), this adds a repo-local `viz-interop` lane instead — the option the issue itself offers ("add a small `viz-interop` job").

## Changes

- **`.github/workflows/viz-interop.yml`** (new, repo-local) — installs `.[dev,viz]` and runs `tests/test_viz.py` + `tests/test_fort14_chilmesh_smoke.py`. **Paths-filtered** to the viz surface (`viz.py`/`api.py`/`fort14.py` + the two test files + `pyproject.toml` + the workflow) so it only spends CI minutes when the exercised code changes.
- **`.github/workflows/LOCAL.md`** — registers the new lane (spec-010 v3 gate requires it).
- **`.domi-pin`** — routine sync `8e259ae → cfa7f02`.

## Acceptance (#197)

- [x] A CI lane installs `.[dev,viz]` and runs the 4 previously-skipped tests.
- [x] The real third-party contract assertion runs in CI — `test_fort14_chilmesh_smoke.py` calls `chilmesh.CHILmesh.read_from_fort14` on admesh2D output and asserts node/element counts + coordinate round-trip. (`test_fort14_chilmesh_compat.py` stays the vanilla-CI self-consistency proxy.)
- [x] Contributor default unchanged — `tests.yml` untouched; plain `.[dev]` + `pytest -m "not slow"` still green, local skips still acceptable.

## Verification

Local (correct interpreter via `python -m pip`/`python -m pytest`): `5 passed in 0.87s` (4 gated tests + the always-run chilmesh-missing fallback). chilmesh 1.3.0 from PyPI; `CHILmesh.read_from_fort14` API confirmed against the sibling checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx5orxydn64sEHcajLTM5p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx5orxydn64sEHcajLTM5p)_